### PR TITLE
feat(config): operator-tunable triage policy (epic #71 slice 1c-i)

### DIFF
--- a/zap-kb/cmd/zap-kb/config_cmd.go
+++ b/zap-kb/cmd/zap-kb/config_cmd.go
@@ -1,0 +1,112 @@
+package main
+
+// config sub-command: surfaces and seeds the operator-tunable triage policy
+// (epic #71 slice 1c-i). Two verbs:
+//
+//	zap-kb config show           # print the resolved policy + which file (if any) it came from
+//	zap-kb config init [-path P] # write a heavily commented default triage-policy.yaml
+//
+// Policy is loaded from triage-policy.yaml in the cwd, then
+// <user-config-home>/devsecopskb/triage-policy.yaml, then built-in defaults.
+// Deliberately no -force on init: the YAML is the org's source of truth, so
+// overwriting must be a manual `rm` step. CLI flags do NOT mirror policy
+// fields — see internal/config/policy.go for the rationale.
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/Warlockobama/DevSecOpsKB/zap-kb/internal/config"
+)
+
+func runConfigCommand(args []string) {
+	if len(args) == 0 {
+		configUsage()
+		os.Exit(2)
+	}
+	switch args[0] {
+	case "show":
+		runConfigShow(args[1:])
+	case "init":
+		runConfigInit(args[1:])
+	case "-h", "--help", "help":
+		configUsage()
+	default:
+		fmt.Fprintf(os.Stderr, "config: unknown subcommand %q\n", args[0])
+		configUsage()
+		os.Exit(2)
+	}
+}
+
+func configUsage() {
+	fmt.Fprintln(os.Stderr, `Usage:
+  zap-kb config show              Show the resolved triage policy and its source.
+  zap-kb config init [-path P]    Write a commented default triage-policy.yaml.
+                                  Default path: ./triage-policy.yaml in cwd.`)
+}
+
+// runConfigShow prints the merged TriagePolicy plus the absolute path of the
+// file it was loaded from (or "(built-in defaults)" if no YAML was found).
+// Output is deliberately JSON so callers can pipe it to jq.
+func runConfigShow(args []string) {
+	fs := flag.NewFlagSet("config show", flag.ExitOnError)
+	if err := fs.Parse(args); err != nil {
+		fmt.Fprintf(os.Stderr, "config show: %v\n", err)
+		os.Exit(1)
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "config show: getwd: %v\n", err)
+		os.Exit(1)
+	}
+	policy, loadedFrom, err := config.LoadPolicy(cwd)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "config show: %v\n", err)
+		os.Exit(1)
+	}
+	src := loadedFrom
+	if src == "" {
+		src = "(built-in defaults)"
+	}
+	out := struct {
+		Source string               `json:"source"`
+		Policy config.TriagePolicy  `json:"policy"`
+	}{src, policy}
+	enc, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "config show: encode: %v\n", err)
+		os.Exit(1)
+	}
+	os.Stdout.Write(enc)
+	os.Stdout.WriteString("\n")
+}
+
+// runConfigInit writes a commented default policy YAML. Refuses to overwrite
+// an existing file — the caller has to delete it first. This is intentional:
+// policy is org-level state, not something to clobber by accident.
+func runConfigInit(args []string) {
+	fs := flag.NewFlagSet("config init", flag.ExitOnError)
+	var path string
+	fs.StringVar(&path, "path", "", "Where to write the YAML (default: ./triage-policy.yaml)")
+	if err := fs.Parse(args); err != nil {
+		fmt.Fprintf(os.Stderr, "config init: %v\n", err)
+		os.Exit(1)
+	}
+	if path == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "config init: getwd: %v\n", err)
+			os.Exit(1)
+		}
+		path = filepath.Join(cwd, config.PolicyFileName)
+	}
+	if err := config.WriteCommentedDefault(path); err != nil {
+		fmt.Fprintf(os.Stderr, "config init: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("Wrote commented default triage policy to %s\n", path)
+	fmt.Println("Edit it to override defaults; partial files are safe (omitted fields keep their defaults).")
+}

--- a/zap-kb/cmd/zap-kb/main.go
+++ b/zap-kb/cmd/zap-kb/main.go
@@ -172,6 +172,10 @@ func main() {
 		runPullCommand(os.Args[2:])
 		return
 	}
+	if len(os.Args) > 1 && os.Args[1] == "config" {
+		runConfigCommand(os.Args[2:])
+		return
+	}
 
 	flag.Parse()
 

--- a/zap-kb/docs/triage-policy.md
+++ b/zap-kb/docs/triage-policy.md
@@ -1,0 +1,67 @@
+# Triage Policy (`triage-policy.yaml`)
+
+`triage-policy.yaml` holds the operator-tunable knobs that govern automated
+triage decisions in the merge pipeline and exporters. It is the **single
+source of truth** for these values — there are deliberately no CLI flags
+that shadow them, so behavior travels with the vault and analysts get a
+consistent view across runs.
+
+Epic #71 (analyst lifecycle) introduced this file so behaviors like
+auto-reopen, auto-suppression, and rule tuning thresholds can be adjusted
+per-org without recompiling.
+
+## Resolution order
+
+`zap-kb` looks for the file in this order and stops at the first hit:
+
+1. `./triage-policy.yaml` in the current working directory (typically the
+   project / vault root). **This wins** — checked-in YAML is authoritative
+   over a per-machine override.
+2. `<user-config-home>/devsecopskb/triage-policy.yaml`
+   (e.g. `~/.config/devsecopskb/triage-policy.yaml` on Linux,
+   `%APPDATA%\devsecopskb\triage-policy.yaml` on Windows).
+3. Built-in defaults (see `internal/config/policy.go:DefaultPolicy()`).
+
+Partial files are safe: any field omitted from the YAML keeps its built-in
+default rather than being zero-valued. So a one-field override file does
+not silently disable everything else.
+
+## Subcommands
+
+```bash
+# Print the resolved policy and where it came from (JSON, pipe-friendly).
+zap-kb config show
+
+# Write a heavily commented default file at ./triage-policy.yaml.
+# Refuses to overwrite an existing file — delete it first if you mean to.
+zap-kb config init
+zap-kb config init -path /custom/location/triage-policy.yaml
+```
+
+## Fields
+
+| Field | Type | Default | Effect |
+|---|---|---|---|
+| `autoReopenOnRecurrence` | bool | `true` | When `Merge()` sees new occurrences for a finding whose status is `fp` or `fixed`, transition status back to `open`, stash `priorStatus`, and append an audit entry. (Epic #71 slice 1b / issue #57.) Set `false` to restore pre-slice-1b behavior where `Recurrence` is advisory only. |
+| `findingFPSuppressionThreshold` | int | `3` | After this many distinct false-positive history entries on a single finding, the pipeline writes an auto-`Suppression` so the finding stops appearing in triage queues. `<=0` disables. (Epic #71 slice 1c-ii.) |
+| `findingFPSuppressionExpiryDays` | int | `90` | Days an auto-`Suppression` lasts before it expires and the finding returns to triage for re-confirmation. Prevents permanent hide-and-forget on findings whose context may have changed. |
+| `ruleTuneScanThreshold` | int | `5` | Aggregate fp count across all findings sharing a `pluginId`. When the total reaches this threshold, the matching `Definition` is tagged `tune-scan` so security engineering can prioritize tuning the detection rule. `<=0` disables. (Epic #71 slice 1c-ii.) |
+| `acceptedDefaultExpiryDays` | int | `180` | Default `acceptedUntil` window applied when an analyst marks a finding `accepted` without supplying their own `acceptedUntil` date. (Epic #71 slice 2 / issue #58 — acceptance-expired report.) |
+
+## Example
+
+```yaml
+# triage-policy.yaml — minimal override; all other fields keep defaults.
+autoReopenOnRecurrence: true
+findingFPSuppressionThreshold: 5
+ruleTuneScanThreshold: 10
+```
+
+## Why YAML and not flags
+
+These are **policy** decisions (security-team scope), not engineering
+knobs. Putting them in CLI flags invites per-invocation drift — one
+analyst runs with `-fp-threshold=2`, another with `-fp-threshold=10`, and
+the auto-suppression behavior becomes non-reproducible. Keeping them in a
+checked-in YAML file means the policy is reviewable, version-controlled,
+and consistent across every run that touches the same vault.

--- a/zap-kb/go.mod
+++ b/zap-kb/go.mod
@@ -1,3 +1,5 @@
 module github.com/Warlockobama/DevSecOpsKB/zap-kb
 
 go 1.18
+
+require gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/zap-kb/go.mod
+++ b/zap-kb/go.mod
@@ -2,4 +2,4 @@ module github.com/Warlockobama/DevSecOpsKB/zap-kb
 
 go 1.18
 
-require gopkg.in/yaml.v3 v3.0.1 // indirect
+require gopkg.in/yaml.v3 v3.0.1

--- a/zap-kb/go.sum
+++ b/zap-kb/go.sum
@@ -1,0 +1,3 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/zap-kb/internal/config/policy.go
+++ b/zap-kb/internal/config/policy.go
@@ -91,11 +91,15 @@ func LoadPolicy(projectRoot string) (TriagePolicy, string, error) {
 			}
 			return DefaultPolicy(), "", fmt.Errorf("read %s: %w", path, err)
 		}
-		p, err := mergeOntoDefaults(data)
-		if err != nil {
-			return DefaultPolicy(), path, fmt.Errorf("parse %s: %w", path, err)
+		abs, aerr := filepath.Abs(path)
+		if aerr != nil {
+			abs = path
 		}
-		return p, path, nil
+		p, perr := mergeOntoDefaults(data)
+		if perr != nil {
+			return DefaultPolicy(), abs, fmt.Errorf("parse %s: %w", abs, perr)
+		}
+		return p, abs, nil
 	}
 	return DefaultPolicy(), "", nil
 }

--- a/zap-kb/internal/config/policy.go
+++ b/zap-kb/internal/config/policy.go
@@ -1,0 +1,189 @@
+// Package config holds operator-tunable triage policy that the merge pipeline
+// and exporters consult instead of hardcoded constants. Policy is loaded from
+// triage-policy.yaml in the project root, falling back to the user's config
+// home, then to in-process defaults. CLI flags do NOT shadow policy values —
+// these are deliberately org-policy decisions, not per-invocation knobs.
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"gopkg.in/yaml.v3"
+)
+
+// PolicyFileName is the canonical filename the loader looks for.
+const PolicyFileName = "triage-policy.yaml"
+
+// TriagePolicy captures every operator-tunable lifecycle decision. Add fields
+// here as new behaviors become configurable; do NOT add CLI flags for the same
+// values — the YAML file is the single source of truth.
+type TriagePolicy struct {
+	// AutoReopenOnRecurrence controls whether Merge() flips fp/fixed findings
+	// back to "open" when new occurrences arrive (epic #71 slice 1b / issue
+	// #57). Disabling this restores the pre-slice-1b behavior where Recurrence
+	// is set as advisory only and the analyst manually re-triages.
+	AutoReopenOnRecurrence bool `yaml:"autoReopenOnRecurrence"`
+
+	// FindingFPSuppressionThreshold is the number of distinct fp history
+	// entries on a single finding required to trigger an auto-Suppression.
+	// Slice 1c-ii consumes this. <=0 disables the behavior.
+	FindingFPSuppressionThreshold int `yaml:"findingFPSuppressionThreshold"`
+
+	// FindingFPSuppressionExpiryDays is how long an auto-Suppression lasts
+	// before it expires and the finding returns to triage queues for
+	// re-confirmation. Prevents noisy findings from hiding forever.
+	FindingFPSuppressionExpiryDays int `yaml:"findingFPSuppressionExpiryDays"`
+
+	// RuleTuneScanThreshold is the total number of fp transitions (summed
+	// across all findings sharing a pluginId) required to tag the
+	// Definition with "tune-scan" — the queue security engineering reviews
+	// for detection-rule tuning. <=0 disables the behavior.
+	RuleTuneScanThreshold int `yaml:"ruleTuneScanThreshold"`
+
+	// AcceptedDefaultExpiryDays is the default acceptedUntil window applied
+	// when an analyst marks a finding "accepted" without supplying their own
+	// acceptedUntil date. Slice 2 (#58) consumes this for the
+	// acceptance-expired report.
+	AcceptedDefaultExpiryDays int `yaml:"acceptedDefaultExpiryDays"`
+}
+
+// DefaultPolicy returns the built-in defaults used when no YAML is present.
+// These are deliberately conservative: behaviors that mutate analyst state
+// (auto-reopen) default ON because they're net-positive; thresholds default
+// to values that produce signal without being noisy.
+func DefaultPolicy() TriagePolicy {
+	return TriagePolicy{
+		AutoReopenOnRecurrence:         true,
+		FindingFPSuppressionThreshold:  3,
+		FindingFPSuppressionExpiryDays: 90,
+		RuleTuneScanThreshold:          5,
+		AcceptedDefaultExpiryDays:      180,
+	}
+}
+
+// LoadPolicy walks the search path and returns the first policy it finds,
+// merged onto DefaultPolicy() so partial YAML files never produce zero-valued
+// fields. The second return value is the absolute path of the file that was
+// loaded ("" when defaults were used, useful for `config show`).
+//
+// Search order:
+//  1. ./triage-policy.yaml in projectRoot (typically the cwd)
+//  2. <user-config-home>/devsecopskb/triage-policy.yaml
+//  3. Built-in defaults
+//
+// Pass projectRoot="" to skip the project-local lookup (useful for tests).
+func LoadPolicy(projectRoot string) (TriagePolicy, string, error) {
+	candidates := []string{}
+	if projectRoot != "" {
+		candidates = append(candidates, filepath.Join(projectRoot, PolicyFileName))
+	}
+	if home, err := userConfigDir(); err == nil && home != "" {
+		candidates = append(candidates, filepath.Join(home, "devsecopskb", PolicyFileName))
+	}
+	for _, path := range candidates {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return DefaultPolicy(), "", fmt.Errorf("read %s: %w", path, err)
+		}
+		p, err := mergeOntoDefaults(data)
+		if err != nil {
+			return DefaultPolicy(), path, fmt.Errorf("parse %s: %w", path, err)
+		}
+		return p, path, nil
+	}
+	return DefaultPolicy(), "", nil
+}
+
+// mergeOntoDefaults parses YAML over a defaults-initialized struct so any
+// field absent from the YAML keeps its default. Use this rather than zero-value
+// unmarshal so a user who only wants to override one field doesn't accidentally
+// disable everything else.
+func mergeOntoDefaults(data []byte) (TriagePolicy, error) {
+	p := DefaultPolicy()
+	if err := yaml.Unmarshal(data, &p); err != nil {
+		return DefaultPolicy(), err
+	}
+	return p, nil
+}
+
+// WriteCommentedDefault writes a heavily commented default YAML to path. Used
+// by `zap-kb config init`. Returns an error if the file already exists (the
+// caller is responsible for asking before overwriting).
+func WriteCommentedDefault(path string) error {
+	if _, err := os.Stat(path); err == nil {
+		return fmt.Errorf("%s already exists; refusing to overwrite", path)
+	}
+	d := DefaultPolicy()
+	content := fmt.Sprintf(`# triage-policy.yaml — operator-tunable triage policy for zap-kb.
+#
+# Loaded from (in order): ./triage-policy.yaml, then
+# <user-config-home>/devsecopskb/triage-policy.yaml, then built-in defaults.
+# Any field omitted here keeps its default — partial files are safe.
+#
+# These are POLICY decisions, not engineering knobs. There are deliberately no
+# CLI flags that shadow them — keep policy in this file so it travels with the
+# vault and so analysts share a consistent view across runs.
+
+# Auto-reopen findings whose status was fp or fixed when new occurrences
+# arrive in a scan. Default: true. Disable to restore the pre-epic-#71-slice-1b
+# behavior where Recurrence is an advisory note and the analyst re-triages by
+# hand. "accepted" is never auto-reopened — slice 2 handles that via expiry.
+autoReopenOnRecurrence: %t
+
+# After this many distinct false-positive history entries on a single finding,
+# zap-kb writes an auto-Suppression so the finding stops appearing in triage
+# queues. Set <=0 to disable. Slice 1c-ii consumes this.
+findingFPSuppressionThreshold: %d
+
+# How many days an auto-Suppression lasts before it expires and the finding
+# returns for re-confirmation. Prevents permanent hide-and-forget on findings
+# whose context may have changed.
+findingFPSuppressionExpiryDays: %d
+
+# Aggregate fp count across all findings under the same pluginId. When the
+# total reaches this threshold, the Definition is tagged "tune-scan" so
+# security engineering can prioritize tuning the detection rule. Set <=0 to
+# disable. Slice 1c-ii consumes this.
+ruleTuneScanThreshold: %d
+
+# Default acceptedUntil window applied when an analyst marks a finding
+# "accepted" without specifying their own acceptedUntil date. Slice 2 (#58)
+# consumes this for the acceptance-expired report.
+acceptedDefaultExpiryDays: %d
+`,
+		d.AutoReopenOnRecurrence,
+		d.FindingFPSuppressionThreshold,
+		d.FindingFPSuppressionExpiryDays,
+		d.RuleTuneScanThreshold,
+		d.AcceptedDefaultExpiryDays,
+	)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(content), 0o644)
+}
+
+// userConfigDir returns the per-user config dir for devsecopskb files. Wraps
+// os.UserConfigDir but tolerates the empty case (returns "" rather than
+// erroring; the caller treats missing config dir as "skip that lookup").
+func userConfigDir() (string, error) {
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		// On odd platforms os.UserConfigDir can return an error; fall back
+		// to ~/.config on unix, %APPDATA% on Windows.
+		if home, herr := os.UserHomeDir(); herr == nil && home != "" {
+			if runtime.GOOS == "windows" {
+				return filepath.Join(home, "AppData", "Roaming"), nil
+			}
+			return filepath.Join(home, ".config"), nil
+		}
+		return "", err
+	}
+	return dir, nil
+}

--- a/zap-kb/internal/config/policy_test.go
+++ b/zap-kb/internal/config/policy_test.go
@@ -1,0 +1,200 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestDefaultPolicy: defaults must be non-zero on every field — they're the
+// safety net when no YAML is present, and a zero default would silently
+// disable a behavior nobody asked to disable.
+func TestDefaultPolicy(t *testing.T) {
+	d := DefaultPolicy()
+	if !d.AutoReopenOnRecurrence {
+		t.Error("AutoReopenOnRecurrence default must be true (slice 1b shipped enabled)")
+	}
+	if d.FindingFPSuppressionThreshold <= 0 {
+		t.Errorf("FindingFPSuppressionThreshold default must be >0, got %d", d.FindingFPSuppressionThreshold)
+	}
+	if d.FindingFPSuppressionExpiryDays <= 0 {
+		t.Errorf("FindingFPSuppressionExpiryDays default must be >0, got %d", d.FindingFPSuppressionExpiryDays)
+	}
+	if d.RuleTuneScanThreshold <= 0 {
+		t.Errorf("RuleTuneScanThreshold default must be >0, got %d", d.RuleTuneScanThreshold)
+	}
+	if d.AcceptedDefaultExpiryDays <= 0 {
+		t.Errorf("AcceptedDefaultExpiryDays default must be >0, got %d", d.AcceptedDefaultExpiryDays)
+	}
+}
+
+// TestLoadPolicy_NoFile: with no YAML on disk and projectRoot pointing at an
+// empty dir, LoadPolicy must return DefaultPolicy() and an empty source path.
+// Use t.TempDir for projectRoot AND override HOME so the user-config-dir branch
+// also resolves to a known-empty location.
+func TestLoadPolicy_NoFile(t *testing.T) {
+	root := t.TempDir()
+	withCleanHome(t)
+	p, src, err := LoadPolicy(root)
+	if err != nil {
+		t.Fatalf("LoadPolicy: %v", err)
+	}
+	if src != "" {
+		t.Errorf("source: want empty (defaults), got %q", src)
+	}
+	if p != DefaultPolicy() {
+		t.Errorf("policy: want defaults %+v, got %+v", DefaultPolicy(), p)
+	}
+}
+
+// TestLoadPolicy_ProjectRootWins: when both the project root and the user
+// config dir contain a triage-policy.yaml, the project-root copy must win.
+// This is the "vault travels with the policy" guarantee — checked-in YAML
+// is always authoritative over a user's per-machine override.
+func TestLoadPolicy_ProjectRootWins(t *testing.T) {
+	root := t.TempDir()
+	home := withCleanHome(t)
+
+	// User-home copy says threshold=99
+	userDir := filepath.Join(home, ".config", "devsecopskb")
+	if err := os.MkdirAll(userDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, filepath.Join(userDir, PolicyFileName),
+		"findingFPSuppressionThreshold: 99\n")
+
+	// Project-root copy says threshold=7 — this should win
+	projPath := filepath.Join(root, PolicyFileName)
+	mustWrite(t, projPath, "findingFPSuppressionThreshold: 7\n")
+
+	p, src, err := LoadPolicy(root)
+	if err != nil {
+		t.Fatalf("LoadPolicy: %v", err)
+	}
+	if src != projPath {
+		t.Errorf("source: want %q, got %q", projPath, src)
+	}
+	if p.FindingFPSuppressionThreshold != 7 {
+		t.Errorf("threshold: project-root must win (want 7), got %d", p.FindingFPSuppressionThreshold)
+	}
+}
+
+// TestLoadPolicy_PartialYAMLPreservesDefaults: a YAML that only sets one field
+// must NOT zero-out the others. This is the whole point of mergeOntoDefaults
+// — a user who overrides one knob shouldn't accidentally disable everything.
+func TestLoadPolicy_PartialYAMLPreservesDefaults(t *testing.T) {
+	root := t.TempDir()
+	withCleanHome(t)
+	mustWrite(t, filepath.Join(root, PolicyFileName),
+		"findingFPSuppressionThreshold: 11\n")
+
+	p, _, err := LoadPolicy(root)
+	if err != nil {
+		t.Fatalf("LoadPolicy: %v", err)
+	}
+	d := DefaultPolicy()
+	if p.FindingFPSuppressionThreshold != 11 {
+		t.Errorf("override field: want 11, got %d", p.FindingFPSuppressionThreshold)
+	}
+	if p.AutoReopenOnRecurrence != d.AutoReopenOnRecurrence {
+		t.Errorf("AutoReopenOnRecurrence: partial YAML must not clobber default (want %v, got %v)",
+			d.AutoReopenOnRecurrence, p.AutoReopenOnRecurrence)
+	}
+	if p.RuleTuneScanThreshold != d.RuleTuneScanThreshold {
+		t.Errorf("RuleTuneScanThreshold: partial YAML must not clobber default (want %d, got %d)",
+			d.RuleTuneScanThreshold, p.RuleTuneScanThreshold)
+	}
+	if p.AcceptedDefaultExpiryDays != d.AcceptedDefaultExpiryDays {
+		t.Errorf("AcceptedDefaultExpiryDays: partial YAML must not clobber default (want %d, got %d)",
+			d.AcceptedDefaultExpiryDays, p.AcceptedDefaultExpiryDays)
+	}
+}
+
+// TestLoadPolicy_InvalidYAML: a malformed YAML must surface as an error
+// rather than silently dropping back to defaults — operator needs to know
+// their config is broken before pipelines drift.
+func TestLoadPolicy_InvalidYAML(t *testing.T) {
+	root := t.TempDir()
+	withCleanHome(t)
+	mustWrite(t, filepath.Join(root, PolicyFileName), "this: : is not: valid: yaml:::\n  - bad")
+	_, _, err := LoadPolicy(root)
+	if err == nil {
+		t.Fatal("expected parse error for malformed YAML, got nil")
+	}
+	if !strings.Contains(err.Error(), "parse") {
+		t.Errorf("error should mention parse failure, got %v", err)
+	}
+}
+
+// TestWriteCommentedDefault_RoundTrip: the YAML written by WriteCommentedDefault
+// must round-trip cleanly back through LoadPolicy and produce DefaultPolicy().
+// This is the contract `zap-kb config init` promises — what you get out the
+// box matches what the binary uses when no file is present.
+func TestWriteCommentedDefault_RoundTrip(t *testing.T) {
+	root := t.TempDir()
+	withCleanHome(t)
+	path := filepath.Join(root, PolicyFileName)
+	if err := WriteCommentedDefault(path); err != nil {
+		t.Fatalf("WriteCommentedDefault: %v", err)
+	}
+	// File should exist and contain comment lines (operator-readable).
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read written file: %v", err)
+	}
+	if !strings.Contains(string(data), "#") {
+		t.Error("written file must contain operator-readable comments")
+	}
+	p, src, err := LoadPolicy(root)
+	if err != nil {
+		t.Fatalf("LoadPolicy: %v", err)
+	}
+	if src != path {
+		t.Errorf("source: want %q, got %q", path, src)
+	}
+	if p != DefaultPolicy() {
+		t.Errorf("round-trip: want defaults %+v, got %+v", DefaultPolicy(), p)
+	}
+}
+
+// TestWriteCommentedDefault_RefusesOverwrite: must not clobber an existing file.
+// Policy is org-level state; an accidental `config init` shouldn't blow away
+// hand-tuned thresholds.
+func TestWriteCommentedDefault_RefusesOverwrite(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, PolicyFileName)
+	mustWrite(t, path, "autoReopenOnRecurrence: false\n")
+	err := WriteCommentedDefault(path)
+	if err == nil {
+		t.Fatal("expected error when target file exists, got nil")
+	}
+	// File must be untouched
+	data, _ := os.ReadFile(path)
+	if !strings.Contains(string(data), "autoReopenOnRecurrence: false") {
+		t.Error("existing file was modified despite refusal")
+	}
+}
+
+// withCleanHome points HOME / XDG_CONFIG_HOME / APPDATA at a fresh temp dir
+// so tests never accidentally pick up a real user's triage-policy.yaml.
+// Returns the temp HOME path so tests can plant fixtures inside it when
+// they want to exercise the user-config-dir branch.
+func withCleanHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("APPDATA", filepath.Join(home, "AppData", "Roaming"))
+	return home
+}
+
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary
First of three sub-slices for epic #71 slice 1c. Ships **only the policy infrastructure** so reviewers can land it independently of the behaviors that consume it.

- New `internal/config` package: `TriagePolicy` struct, `DefaultPolicy()`, `LoadPolicy()` (project-root → user-config-home → defaults), `WriteCommentedDefault()`.
- Partial YAML files merge onto defaults — one-field overrides don't zero the rest.
- New `zap-kb config` subcommand: `show` (resolved policy + source as JSON) and `init` (write commented default; refuses to overwrite).
- Docs: `docs/triage-policy.md` schema reference + rationale (policy lives in YAML, not flags).

## Stacked PR
Base = `claude/epic71-slice1b-reopen-on-recurrence` (PR #?). Merge slice 1b first, then this rebases onto main cleanly.

## Coming next
- **1c-ii**: `MergeWithPolicy(base, add, policy)` — auto-suppress findings after N fp entries; tag `Definition` `tune-scan` after aggregate threshold; auto-reopen becomes policy-toggleable.
- **1c-iii**: extend the existing wizard with a "Triage policy" section that reads/writes this YAML.

## Test plan
- [x] `go test ./...` (config + cmd + entities all green)
- [x] `go vet ./...`, `go build ./...`
- [ ] Reviewer: run `zap-kb config init && zap-kb config show` and confirm round-trip
- [ ] Reviewer: confirm partial YAML (one field) doesn't zero the rest

Refs #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)