### PR TITLE
feat(entities): policy-driven merge — auto-suppress + tune-scan (epic #71 slice 1c-ii)

### DIFF
--- a/zap-kb/cmd/zap-kb/main.go
+++ b/zap-kb/cmd/zap-kb/main.go
@@ -202,7 +202,13 @@ func main() {
 	// inside entities.MergeWithPolicy. When no YAML is present the call
 	// falls back to config.DefaultPolicy() — which matches pre-epic-#71 behavior
 	// for the auto-reopen toggle. See docs/triage-policy.md.
-	cwdForPolicy, _ := os.Getwd()
+	cwdForPolicy, cwdErr := os.Getwd()
+	if cwdErr != nil {
+		// Surface the failure: policy still loads from user-config/defaults,
+		// but operators deserve a warning when project-local lookup is skipped.
+		log.Printf("[warn] cannot determine working directory for triage policy lookup: %v", cwdErr)
+		cwdForPolicy = ""
+	}
 	triagePolicy, policySrc, perr := config.LoadPolicy(cwdForPolicy)
 	if perr != nil {
 		// Broken YAML should surface loudly; silently falling back to defaults

--- a/zap-kb/cmd/zap-kb/main.go
+++ b/zap-kb/cmd/zap-kb/main.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Warlockobama/DevSecOpsKB/zap-kb/internal/config"
 	"github.com/Warlockobama/DevSecOpsKB/zap-kb/internal/entities"
 	"github.com/Warlockobama/DevSecOpsKB/zap-kb/internal/output/confluence"
 	"github.com/Warlockobama/DevSecOpsKB/zap-kb/internal/output/jira"
@@ -195,6 +196,22 @@ func main() {
 	envFallback(&confToken, "CONFLUENCE_TOKEN")
 	envFallback(&jiraUser, "JIRA_USER")
 	envFallback(&jiraToken, "JIRA_API_TOKEN")
+
+	// Load operator-tunable triage policy once at startup. This drives the
+	// auto-reopen gate, auto-suppression cadence, and rule-tune-scan tagging
+	// inside entities.MergeWithPolicy. When no YAML is present the call
+	// falls back to config.DefaultPolicy() — which matches pre-epic-#71 behavior
+	// for the auto-reopen toggle. See docs/triage-policy.md.
+	cwdForPolicy, _ := os.Getwd()
+	triagePolicy, policySrc, perr := config.LoadPolicy(cwdForPolicy)
+	if perr != nil {
+		// Broken YAML should surface loudly; silently falling back to defaults
+		// hides policy drift from operators who think their overrides are live.
+		log.Fatalf("triage policy: %v", perr)
+	}
+	if policySrc != "" {
+		fmt.Fprintf(os.Stderr, "[info] triage policy loaded from %s\n", policySrc)
+	}
 
 	// Prune-only mode: delete occurrence files by scan label (and optional site) from the vault, then refresh INDEX/DASHBOARD
 	if strings.TrimSpace(pruneScanLabel) != "" {
@@ -440,7 +457,7 @@ func main() {
 			if len(ent.Definitions) == 0 && len(ent.Findings) == 0 && len(ent.Occurrences) == 0 {
 				ent = built
 			} else {
-				ent = entities.Merge(ent, built)
+				ent = entities.MergeWithPolicy(ent, built, triagePolicy)
 			}
 		}
 
@@ -947,9 +964,21 @@ func runMergeCommand(args []string) {
 		artifacts = append(artifacts, art.Entities)
 	}
 
+	// Load triage policy so post-merge passes (auto-suppression, tune-scan
+	// tagging) run the same way as the main pipeline. A broken YAML fails the
+	// sub-command rather than silently falling back to defaults.
+	cwd, _ := os.Getwd()
+	policy, policySrc, perr := config.LoadPolicy(cwd)
+	if perr != nil {
+		fmt.Fprintf(os.Stderr, "merge: triage policy: %v\n", perr)
+		os.Exit(1)
+	}
+	if policySrc != "" {
+		fmt.Fprintf(os.Stderr, "merge: triage policy loaded from %s\n", policySrc)
+	}
 	merged := artifacts[0]
 	for _, ef := range artifacts[1:] {
-		merged = entities.Merge(merged, ef)
+		merged = entities.MergeWithPolicy(merged, ef, policy)
 	}
 
 	// Encode output.

--- a/zap-kb/internal/entities/merge.go
+++ b/zap-kb/internal/entities/merge.go
@@ -5,6 +5,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/Warlockobama/DevSecOpsKB/zap-kb/internal/config"
 )
 
 // mergeAnalyst performs field-level merge of two Analyst annotations.
@@ -139,11 +141,38 @@ func unionStrings(a, b []string) []string {
 	return out
 }
 
-// Merge returns a new EntitiesFile which is the union of base and add.
-// - Definitions: union by definitionId; prefer base; fill missing Detection/Taxonomy/Remediation from add when absent.
-// - Findings: union by findingId; prefer base fields; occurrenceCount is recomputed.
-// - Occurrences: union by occurrenceId (dedup), then sorted.
+// Merge returns a new EntitiesFile which is the union of base and add, run
+// through the merge pipeline with the org's DEFAULT triage policy. Most
+// callers should use this; pass an explicit policy via MergeWithPolicy when
+// the caller has loaded triage-policy.yaml itself (e.g. cmd/zap-kb/main.go
+// calls LoadPolicy once at startup and threads the result through).
+//
+// Behaviors driven by the policy (epic #71 slice 1c-ii):
+//   - AutoReopenOnRecurrence: gate on/off the slice 1b auto-reopen of fp/fixed
+//     findings when new occurrences arrive.
+//   - FindingFPSuppressionThreshold/ExpiryDays: after N "auto-reopened from fp"
+//     history entries on a single finding, the pipeline writes a finding-scoped
+//     Suppression so the noisy detection stops nagging the analyst.
+//   - RuleTuneScanThreshold: after the same threshold of fp-reopens aggregated
+//     across all findings sharing a pluginId, tag the Definition "tune-scan"
+//     so security engineering knows to retune the detection rule.
 func Merge(base, add EntitiesFile) EntitiesFile {
+	return MergeWithPolicy(base, add, config.DefaultPolicy())
+}
+
+// MergeWithPolicy is Merge with an explicit operator-tunable policy. See
+// internal/config/policy.go for the policy schema.
+func MergeWithPolicy(base, add EntitiesFile, policy config.TriagePolicy) EntitiesFile {
+	out := mergeCore(base, add, policy)
+	applyFindingFPAutoSuppression(&out, policy)
+	applyRuleTuneScanTags(&out, policy)
+	return out
+}
+
+// mergeCore is the union/merge work; it does NOT apply the post-merge policy
+// passes (auto-suppression, tune-scan tagging). Split out so unit tests can
+// exercise the auto-reopen gate without dragging the suppression machinery in.
+func mergeCore(base, add EntitiesFile, policy config.TriagePolicy) EntitiesFile {
 	out := base
 
 	// Index base definitions by id
@@ -315,7 +344,8 @@ func Merge(base, add EntitiesFile) EntitiesFile {
 	// in this merge, we always set an advisory RecurrenceInfo.
 	//
 	// For fp and fixed findings specifically, we additionally transition the
-	// analyst status back to "open" and append a deterministic history entry.
+	// analyst status back to "open" and append a deterministic history entry,
+	// gated by policy.AutoReopenOnRecurrence (slice 1c-ii made this toggleable).
 	// "accepted" is NOT auto-reopened: acceptance is a time-bounded analyst
 	// decision (acceptedUntil) handled separately by slice 2.
 	{
@@ -380,7 +410,11 @@ func Merge(base, add EntitiesFile) EntitiesFile {
 				}
 			}
 
-			// Auto-reopen for fp/fixed. Skip accepted.
+			// Auto-reopen for fp/fixed. Skip accepted. Skip entirely when the
+			// org has disabled the behavior in triage-policy.yaml.
+			if !policy.AutoReopenOnRecurrence {
+				continue
+			}
 			if _, shouldReopen := reopenStatuses[priorStatus]; !shouldReopen {
 				continue
 			}

--- a/zap-kb/internal/entities/merge_policy.go
+++ b/zap-kb/internal/entities/merge_policy.go
@@ -1,0 +1,164 @@
+package entities
+
+// Post-merge policy passes (epic #71 slice 1c-ii). Run AFTER mergeCore so
+// the analyst.History on each finding already reflects the union of all
+// inputs and any auto-reopen entries the current merge appended.
+//
+// Two passes are wired here:
+//
+//   - Finding-level auto-suppression: when a single finding has accumulated
+//     N "auto-reopened from fp" history entries — i.e. the analyst confirmed
+//     fp, the detection found it again, the analyst confirmed fp again, and
+//     so on — write a finding-scoped Suppression so the loop ends. Bounded
+//     by FindingFPSuppressionExpiryDays so the finding eventually re-enters
+//     triage in case the underlying context (app code, scope) has changed.
+//
+//   - Rule-level tune-scan tag: aggregate the same fp-reopen count across
+//     every finding sharing a pluginId. When the rule-wide total crosses the
+//     threshold, tag the matching Definition's Taxonomy.Tags with "tune-scan".
+//     That's the queue security engineering reviews to retune detection rules.
+//
+// Both passes are idempotent: rerunning the same merge does not duplicate
+// suppressions or tags.
+
+import (
+	"strings"
+	"time"
+
+	"github.com/Warlockobama/DevSecOpsKB/zap-kb/internal/config"
+)
+
+// pipelineAutoSuppressDecidedBy marks suppressions written by this pass so we
+// can tell them apart from analyst-written ones. Analyst-written suppressions
+// are NEVER overwritten by the pipeline; only an existing pipeline-written
+// suppression that has expired is refreshed.
+const pipelineAutoSuppressDecidedBy = "pipeline:auto-suppress"
+
+// countFPReopens returns how many AnalystHistoryEntry rows on a finding
+// represent "auto-reopened from fp" — i.e. status=open AND priorStatus=fp.
+// Each such entry corresponds to one full cycle of: analyst flagged fp →
+// detection found it again → pipeline reopened. Counting these is a more
+// honest signal than counting all history entries (analyst-driven status
+// changes don't currently create history rows).
+func countFPReopens(history []AnalystHistoryEntry) int {
+	n := 0
+	for _, e := range history {
+		if strings.EqualFold(strings.TrimSpace(e.Status), "open") &&
+			strings.EqualFold(strings.TrimSpace(e.PriorStatus), "fp") {
+			n++
+		}
+	}
+	return n
+}
+
+// applyFindingFPAutoSuppression walks every finding and writes a
+// finding-scoped Suppression when the fp-reopen count meets the threshold.
+//
+// Skipped when:
+//   - policy threshold <= 0 (operator opted out)
+//   - the finding already carries an analyst-written Suppression (we never
+//     stomp on a human decision; the analyst can clear it themselves)
+//   - the finding already carries a pipeline-written Suppression that is
+//     still in-window — refresh only after expiry so the cadence is
+//     predictable
+func applyFindingFPAutoSuppression(ef *EntitiesFile, policy config.TriagePolicy) {
+	if policy.FindingFPSuppressionThreshold <= 0 {
+		return
+	}
+	now := time.Now().UTC()
+	expires := ""
+	if policy.FindingFPSuppressionExpiryDays > 0 {
+		expires = now.AddDate(0, 0, policy.FindingFPSuppressionExpiryDays).Format(time.RFC3339)
+	}
+	nowStr := now.Format(time.RFC3339)
+	for i := range ef.Findings {
+		f := &ef.Findings[i]
+		if f.Analyst == nil || len(f.Analyst.History) == 0 {
+			continue
+		}
+		count := countFPReopens(f.Analyst.History)
+		if count < policy.FindingFPSuppressionThreshold {
+			continue
+		}
+		// Respect existing analyst-authored Suppression entirely.
+		if f.Suppression != nil &&
+			!strings.EqualFold(strings.TrimSpace(f.Suppression.DecidedBy), pipelineAutoSuppressDecidedBy) {
+			continue
+		}
+		// Respect a still-valid pipeline suppression so we don't churn the
+		// expiresAt field on every merge.
+		if f.Suppression != nil && f.Suppression.ExpiresAt != "" {
+			if exp, err := time.Parse(time.RFC3339, f.Suppression.ExpiresAt); err == nil && exp.After(now) {
+				continue
+			}
+		}
+		f.Suppression = &Suppression{
+			Scope:     "finding",
+			Reason:    "auto-suppressed: " + itoa(count) + " confirmed false-positive recurrences exceed threshold",
+			DecidedBy: pipelineAutoSuppressDecidedBy,
+			DecidedAt: nowStr,
+			ExpiresAt: expires,
+		}
+	}
+}
+
+// applyRuleTuneScanTags aggregates fp-reopen counts across every finding
+// sharing a pluginId; when the rule-wide total meets the threshold, the
+// matching Definition's Taxonomy.Tags receives "tune-scan" (idempotent).
+//
+// Skipped when policy threshold <= 0 (operator opted out).
+func applyRuleTuneScanTags(ef *EntitiesFile, policy config.TriagePolicy) {
+	if policy.RuleTuneScanThreshold <= 0 {
+		return
+	}
+	totals := make(map[string]int)
+	for _, f := range ef.Findings {
+		pid := strings.TrimSpace(f.PluginID)
+		if pid == "" || f.Analyst == nil {
+			continue
+		}
+		totals[pid] += countFPReopens(f.Analyst.History)
+	}
+	if len(totals) == 0 {
+		return
+	}
+	for i := range ef.Definitions {
+		d := &ef.Definitions[i]
+		pid := strings.TrimSpace(d.PluginID)
+		if pid == "" {
+			continue
+		}
+		if totals[pid] < policy.RuleTuneScanThreshold {
+			continue
+		}
+		if d.Taxonomy == nil {
+			d.Taxonomy = &Taxonomy{}
+		}
+		// unionStrings preserves order and de-dupes; safe to call repeatedly.
+		d.Taxonomy.Tags = unionStrings(d.Taxonomy.Tags, []string{"tune-scan"})
+	}
+}
+
+// itoa: tiny local copy so this file doesn't pull in strconv just for a
+// single Sprintf in a Reason string. Threshold values are small integers.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}

--- a/zap-kb/internal/entities/merge_policy.go
+++ b/zap-kb/internal/entities/merge_policy.go
@@ -86,15 +86,20 @@ func applyFindingFPAutoSuppression(ef *EntitiesFile, policy config.TriagePolicy)
 			continue
 		}
 		// Respect a still-valid pipeline suppression so we don't churn the
-		// expiresAt field on every merge.
-		if f.Suppression != nil && f.Suppression.ExpiresAt != "" {
+		// expiresAt field on every merge. A pipeline suppression with an empty
+		// ExpiresAt is documented as permanent — treat it as still valid rather
+		// than rewriting it on every run.
+		if f.Suppression != nil {
+			if f.Suppression.ExpiresAt == "" {
+				continue
+			}
 			if exp, err := time.Parse(time.RFC3339, f.Suppression.ExpiresAt); err == nil && exp.After(now) {
 				continue
 			}
 		}
 		f.Suppression = &Suppression{
 			Scope:     "finding",
-			Reason:    "auto-suppressed: " + itoa(count) + " confirmed false-positive recurrences exceed threshold",
+			Reason:    "auto-suppressed: " + itoa(count) + " confirmed false-positive recurrences meet or exceed threshold",
 			DecidedBy: pipelineAutoSuppressDecidedBy,
 			DecidedAt: nowStr,
 			ExpiresAt: expires,

--- a/zap-kb/internal/entities/merge_policy_test.go
+++ b/zap-kb/internal/entities/merge_policy_test.go
@@ -1,0 +1,260 @@
+package entities
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Warlockobama/DevSecOpsKB/zap-kb/internal/config"
+)
+
+// findingWithFPReopens builds a finding whose History contains n synthetic
+// "auto-reopened from fp" entries — each one represents one full cycle of
+// "analyst said fp, detection found it again." Used to drive the auto-
+// suppression and tune-scan tagging tests without standing up a full multi-
+// merge fixture.
+func findingWithFPReopens(findingID, pluginID string, n int) Finding {
+	hist := make([]AnalystHistoryEntry, 0, n)
+	for i := 0; i < n; i++ {
+		// Use distinct scanLabels so EntryIDs don't collide and we genuinely
+		// see n entries after history-union dedup.
+		entry := NewAnalystHistoryEntry(
+			"scan-fp-cycle-"+itoa(i),
+			"open", "fp",
+			"alice",
+			"auto-reopened: recurrence in scan scan-fp-cycle-"+itoa(i),
+			"2026-04-2"+itoa(i%9)+"T10:00:00Z",
+		)
+		hist = append(hist, entry)
+	}
+	return Finding{
+		FindingID: findingID,
+		PluginID:  pluginID,
+		URL:       "https://example.com/x",
+		Method:    "GET",
+		Analyst:   &Analyst{Status: "fp", Owner: "alice", History: hist},
+	}
+}
+
+// TestMergeWithPolicy_AutoReopenGate: with AutoReopenOnRecurrence=false,
+// a recurring fp finding gets the advisory Recurrence record but status
+// stays "fp" and no history is appended. Mirrors slice 1b's "do not reopen
+// accepted" guarantee — but applied org-wide via policy.
+func TestMergeWithPolicy_AutoReopenGate(t *testing.T) {
+	base, add := reopenFixture("fp", "alice", "scan-2026-04-21", "2026-04-21T10:00:00Z")
+	policy := config.DefaultPolicy()
+	policy.AutoReopenOnRecurrence = false
+	merged := MergeWithPolicy(base, add, policy)
+	f := merged.Findings[0]
+	if f.Analyst.Status != "fp" {
+		t.Errorf("Status: gate=false must preserve fp, got %q", f.Analyst.Status)
+	}
+	if len(f.Analyst.History) != 0 {
+		t.Errorf("History: gate=false must not append entries, got %+v", f.Analyst.History)
+	}
+	if f.Recurrence == nil {
+		t.Error("Recurrence advisory must still be set even when reopen disabled")
+	}
+}
+
+// TestApplyAutoSuppression_WritesAfterThreshold: a finding with N fp-reopen
+// history entries (where N == threshold) gets a pipeline-written Suppression
+// scoped to the finding, with expiresAt set N days out.
+func TestApplyAutoSuppression_WritesAfterThreshold(t *testing.T) {
+	policy := config.DefaultPolicy() // threshold=3, expiry=90
+	ef := EntitiesFile{
+		SchemaVersion: "v1",
+		Findings:      []Finding{findingWithFPReopens("fin-1", "10001", 3)},
+	}
+	applyFindingFPAutoSuppression(&ef, policy)
+	s := ef.Findings[0].Suppression
+	if s == nil {
+		t.Fatal("Suppression must be set when fp-reopens >= threshold")
+	}
+	if s.Scope != "finding" {
+		t.Errorf("Scope: want finding, got %q", s.Scope)
+	}
+	if s.DecidedBy != pipelineAutoSuppressDecidedBy {
+		t.Errorf("DecidedBy: want %q, got %q", pipelineAutoSuppressDecidedBy, s.DecidedBy)
+	}
+	if s.ExpiresAt == "" {
+		t.Error("ExpiresAt must be set (expiry days > 0)")
+	}
+	exp, err := time.Parse(time.RFC3339, s.ExpiresAt)
+	if err != nil {
+		t.Fatalf("ExpiresAt not RFC3339: %v", err)
+	}
+	delta := time.Until(exp)
+	wantMin := time.Duration(policy.FindingFPSuppressionExpiryDays-1) * 24 * time.Hour
+	wantMax := time.Duration(policy.FindingFPSuppressionExpiryDays+1) * 24 * time.Hour
+	if delta < wantMin || delta > wantMax {
+		t.Errorf("ExpiresAt should be ~%d days out, got delta=%v", policy.FindingFPSuppressionExpiryDays, delta)
+	}
+}
+
+// TestApplyAutoSuppression_BelowThresholdNoOp: under threshold, no Suppression.
+func TestApplyAutoSuppression_BelowThresholdNoOp(t *testing.T) {
+	policy := config.DefaultPolicy() // threshold=3
+	ef := EntitiesFile{Findings: []Finding{findingWithFPReopens("fin-1", "10001", 2)}}
+	applyFindingFPAutoSuppression(&ef, policy)
+	if ef.Findings[0].Suppression != nil {
+		t.Errorf("Suppression must NOT be set below threshold, got %+v", ef.Findings[0].Suppression)
+	}
+}
+
+// TestApplyAutoSuppression_DisabledByZeroThreshold: threshold<=0 must short
+// circuit even with abundant history, so operators can opt out cleanly.
+func TestApplyAutoSuppression_DisabledByZeroThreshold(t *testing.T) {
+	policy := config.DefaultPolicy()
+	policy.FindingFPSuppressionThreshold = 0
+	ef := EntitiesFile{Findings: []Finding{findingWithFPReopens("fin-1", "10001", 99)}}
+	applyFindingFPAutoSuppression(&ef, policy)
+	if ef.Findings[0].Suppression != nil {
+		t.Error("Suppression must NOT be written when threshold disabled")
+	}
+}
+
+// TestApplyAutoSuppression_RespectsAnalystSuppression: an analyst-written
+// Suppression (DecidedBy != pipeline) is NEVER overwritten — humans always
+// win.
+func TestApplyAutoSuppression_RespectsAnalystSuppression(t *testing.T) {
+	policy := config.DefaultPolicy()
+	f := findingWithFPReopens("fin-1", "10001", 5)
+	f.Suppression = &Suppression{
+		Scope: "occurrence", DecidedBy: "alice@example.com", Reason: "intentional",
+	}
+	ef := EntitiesFile{Findings: []Finding{f}}
+	applyFindingFPAutoSuppression(&ef, policy)
+	got := ef.Findings[0].Suppression
+	if got == nil || got.DecidedBy != "alice@example.com" {
+		t.Errorf("analyst suppression must be preserved, got %+v", got)
+	}
+}
+
+// TestApplyAutoSuppression_RefreshesOnlyAfterExpiry: an existing pipeline-
+// written suppression with a future expiry is left alone (no field churn);
+// once it has expired, the next pass refreshes it.
+func TestApplyAutoSuppression_RefreshesOnlyAfterExpiry(t *testing.T) {
+	policy := config.DefaultPolicy()
+	f := findingWithFPReopens("fin-1", "10001", 5)
+	future := time.Now().UTC().Add(30 * 24 * time.Hour).Format(time.RFC3339)
+	f.Suppression = &Suppression{
+		Scope: "finding", DecidedBy: pipelineAutoSuppressDecidedBy,
+		DecidedAt: "2026-01-01T00:00:00Z", ExpiresAt: future,
+	}
+	ef := EntitiesFile{Findings: []Finding{f}}
+	applyFindingFPAutoSuppression(&ef, policy)
+	if ef.Findings[0].Suppression.DecidedAt != "2026-01-01T00:00:00Z" {
+		t.Errorf("in-window pipeline suppression must not be churned, got DecidedAt=%q",
+			ef.Findings[0].Suppression.DecidedAt)
+	}
+
+	// Now expire it and re-run; DecidedAt should advance.
+	past := time.Now().UTC().Add(-24 * time.Hour).Format(time.RFC3339)
+	ef.Findings[0].Suppression.ExpiresAt = past
+	applyFindingFPAutoSuppression(&ef, policy)
+	if ef.Findings[0].Suppression.DecidedAt == "2026-01-01T00:00:00Z" {
+		t.Error("expired pipeline suppression must be refreshed (DecidedAt advances)")
+	}
+}
+
+// TestApplyTuneScanTags_AggregatesAcrossFindings: fp-reopen counts across
+// findings sharing a pluginId roll up into one rule-level total. When the
+// total meets RuleTuneScanThreshold (default 5), the matching Definition's
+// Taxonomy.Tags receives "tune-scan".
+func TestApplyTuneScanTags_AggregatesAcrossFindings(t *testing.T) {
+	policy := config.DefaultPolicy() // ruleTuneScan=5
+	ef := EntitiesFile{
+		Definitions: []Definition{{DefinitionID: "def-10001", PluginID: "10001"}},
+		Findings: []Finding{
+			findingWithFPReopens("fin-a", "10001", 3),
+			findingWithFPReopens("fin-b", "10001", 2),
+		},
+	}
+	applyRuleTuneScanTags(&ef, policy)
+	d := ef.Definitions[0]
+	if d.Taxonomy == nil {
+		t.Fatal("Taxonomy must be initialized when tag added")
+	}
+	if !contains(d.Taxonomy.Tags, "tune-scan") {
+		t.Errorf("tune-scan tag missing, got tags=%v", d.Taxonomy.Tags)
+	}
+}
+
+// TestApplyTuneScanTags_BelowThresholdNoTag: 4 fp reopens total < 5 threshold.
+func TestApplyTuneScanTags_BelowThresholdNoTag(t *testing.T) {
+	policy := config.DefaultPolicy()
+	ef := EntitiesFile{
+		Definitions: []Definition{{DefinitionID: "def-10001", PluginID: "10001"}},
+		Findings:    []Finding{findingWithFPReopens("fin-a", "10001", 4)},
+	}
+	applyRuleTuneScanTags(&ef, policy)
+	if ef.Definitions[0].Taxonomy != nil && contains(ef.Definitions[0].Taxonomy.Tags, "tune-scan") {
+		t.Error("tune-scan tag must NOT be added below threshold")
+	}
+}
+
+// TestApplyTuneScanTags_Idempotent: running the pass twice does not produce
+// duplicate "tune-scan" tags (unionStrings handles dedup).
+func TestApplyTuneScanTags_Idempotent(t *testing.T) {
+	policy := config.DefaultPolicy()
+	ef := EntitiesFile{
+		Definitions: []Definition{{DefinitionID: "def-10001", PluginID: "10001"}},
+		Findings:    []Finding{findingWithFPReopens("fin-a", "10001", 5)},
+	}
+	applyRuleTuneScanTags(&ef, policy)
+	applyRuleTuneScanTags(&ef, policy)
+	count := 0
+	for _, tag := range ef.Definitions[0].Taxonomy.Tags {
+		if tag == "tune-scan" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("tune-scan must appear exactly once after idempotent reruns, got %d", count)
+	}
+}
+
+// TestApplyTuneScanTags_DisabledByZeroThreshold: opt-out path.
+func TestApplyTuneScanTags_DisabledByZeroThreshold(t *testing.T) {
+	policy := config.DefaultPolicy()
+	policy.RuleTuneScanThreshold = 0
+	ef := EntitiesFile{
+		Definitions: []Definition{{DefinitionID: "def-10001", PluginID: "10001"}},
+		Findings:    []Finding{findingWithFPReopens("fin-a", "10001", 99)},
+	}
+	applyRuleTuneScanTags(&ef, policy)
+	if ef.Definitions[0].Taxonomy != nil && contains(ef.Definitions[0].Taxonomy.Tags, "tune-scan") {
+		t.Error("tune-scan must not be added when threshold disabled")
+	}
+}
+
+// TestMergeWithPolicy_EndToEnd: a recurring fp finding goes through
+// Merge → auto-reopen (history entry appended) → still under threshold
+// after one cycle, no suppression. Sanity check that the wrapper plumbs
+// through correctly.
+func TestMergeWithPolicy_EndToEnd(t *testing.T) {
+	base, add := reopenFixture("fp", "alice", "scan-1", "2026-04-21T10:00:00Z")
+	policy := config.DefaultPolicy()
+	merged := MergeWithPolicy(base, add, policy)
+	f := merged.Findings[0]
+	if f.Analyst.Status != "open" {
+		t.Errorf("Status: want open after reopen, got %q", f.Analyst.Status)
+	}
+	// Only one fp-reopen cycle so far → no suppression yet.
+	if f.Suppression != nil {
+		t.Errorf("Suppression must not fire after one cycle, got %+v", f.Suppression)
+	}
+	if !strings.Contains(f.Analyst.History[0].Notes, "auto-reopened") {
+		t.Errorf("expected auto-reopened history note, got %q", f.Analyst.History[0].Notes)
+	}
+}
+
+func contains(ss []string, want string) bool {
+	for _, s := range ss {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}

--- a/zap-kb/internal/entities/merge_policy_test.go
+++ b/zap-kb/internal/entities/merge_policy_test.go
@@ -158,6 +158,33 @@ func TestApplyAutoSuppression_RefreshesOnlyAfterExpiry(t *testing.T) {
 	}
 }
 
+// TestApplyAutoSuppression_ZeroExpiryDaysIsPermanentAndDoesNotChurn:
+// FindingFPSuppressionExpiryDays <= 0 produces an empty ExpiresAt
+// ("permanent" per Suppression docs). The refresh guard must treat that as
+// still-valid so re-running the pipeline never rewrites DecidedAt.
+func TestApplyAutoSuppression_ZeroExpiryDaysIsPermanentAndDoesNotChurn(t *testing.T) {
+	policy := config.DefaultPolicy()
+	policy.FindingFPSuppressionExpiryDays = 0 // permanent suppressions
+	ef := EntitiesFile{Findings: []Finding{findingWithFPReopens("fin-1", "10001", 5)}}
+
+	applyFindingFPAutoSuppression(&ef, policy)
+	s := ef.Findings[0].Suppression
+	if s == nil {
+		t.Fatal("expected pipeline suppression, got nil")
+	}
+	if s.ExpiresAt != "" {
+		t.Errorf("expiryDays<=0 must produce empty ExpiresAt (permanent), got %q", s.ExpiresAt)
+	}
+	firstDecidedAt := s.DecidedAt
+
+	// Re-run: permanent pipeline suppression must not be rewritten.
+	applyFindingFPAutoSuppression(&ef, policy)
+	if ef.Findings[0].Suppression.DecidedAt != firstDecidedAt {
+		t.Errorf("permanent pipeline suppression must not churn on re-run: before=%q after=%q",
+			firstDecidedAt, ef.Findings[0].Suppression.DecidedAt)
+	}
+}
+
 // TestApplyTuneScanTags_AggregatesAcrossFindings: fp-reopen counts across
 // findings sharing a pluginId roll up into one rule-level total. When the
 // total meets RuleTuneScanThreshold (default 5), the matching Definition's


### PR DESCRIPTION
## Summary
Second sub-slice for epic #71 slice 1c. Makes the policy YAML actually **do** something: the values exposed by 1c-i now gate real behaviors in the merge pipeline.

- \`MergeWithPolicy(base, add, policy)\` — new public entry. \`Merge()\` is now a thin wrapper using \`config.DefaultPolicy()\`.
- \`AutoReopenOnRecurrence=false\` disables slice 1b's fp/fixed auto-reopen; advisory \`Recurrence\` still recorded.
- \`FindingFPSuppressionThreshold/ExpiryDays\` — after N "auto-reopened from fp" history entries on one finding, write a pipeline Suppression (scope=finding). Never stomps analyst-authored suppressions; refreshes pipeline ones only after expiry.
- \`RuleTuneScanThreshold\` — aggregate count per pluginId; crossing threshold tags the Definition \`tune-scan\`. Idempotent.
- \`cmd/zap-kb\` + \`merge\` subcommand now \`LoadPolicy\` at startup and fail loudly on broken YAML.

## Signal choice
Counts \`history[].status=="open" && priorStatus=="fp"\` entries — these are unambiguous "analyst said fp, detection found it again" cycles. Counting raw fp history would undercount (analyst-driven status changes don't currently create history rows).

## Stacked PR
Base = \`claude/epic71-slice1c-i-policy-config\` (PR #74).

## Coming next
- **1c-iii**: TUI onboarding (Bubble Tea) so the policy is editable without hand-writing YAML.
- **1c-iv**: local web GUI onboarding (browser-based setup walkthrough).

## Test plan
- [x] \`go test ./...\` — entities, config, cmd all green
- [x] \`go vet ./...\`, \`go build ./...\`
- [x] 10 new tests cover: gate on/off, threshold edges, analyst-suppression precedence, refresh-after-expiry, aggregate tagging, idempotency, end-to-end
- [ ] Reviewer: drop an override YAML, run a re-merge with a recurring fp finding, watch \`Suppression\` appear in the entities JSON

Refs #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)