### PR TITLE
feat(webui): browser-based triage-policy onboarding (epic #71 slice 1c-iv)

### DIFF
--- a/zap-kb/cmd/zap-kb/expired_cmd.go
+++ b/zap-kb/cmd/zap-kb/expired_cmd.go
@@ -1,0 +1,186 @@
+package main
+
+// expired sub-command: reports findings whose risk-acceptance has lapsed
+// (epic #71 slice 2, issue #58).
+//
+// Usage:
+//
+//	zap-kb expired -entities-in ef.json [-format csv|json] [-out path]
+//
+// A finding enters the expired list when:
+//   - analyst.status == "accepted"  AND
+//   - analyst.acceptedUntil is a valid RFC3339 date that is in the past.
+//
+// Findings with status=accepted but no acceptedUntil are treated as indefinitely
+// accepted and are NOT included in the expired list. A stderr warning is emitted
+// for each so operators can decide whether to add an expiry date.
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/Warlockobama/DevSecOpsKB/zap-kb/internal/entities"
+	"github.com/Warlockobama/DevSecOpsKB/zap-kb/internal/output/runartifact"
+)
+
+// expiredRow is one entry in the acceptance-expired report.
+type expiredRow struct {
+	FindingID     string `json:"finding_id"`
+	RuleTitle     string `json:"rule_title"`
+	Severity      string `json:"severity"`
+	Domain        string `json:"domain"`
+	Owner         string `json:"owner"`
+	AcceptedUntil string `json:"accepted_until"`
+	ExpiredAgo    string `json:"expired_ago"`
+	Notes         string `json:"notes"`
+}
+
+// buildExpiredRows returns findings whose acceptance has lapsed and a separate
+// list of finding IDs that are accepted with no expiry date (indefinite).
+// Expired rows are sorted most-overdue first (earliest acceptedUntil first),
+// then by FindingID for stability.
+func buildExpiredRows(ef entities.EntitiesFile, now time.Time) (expired []expiredRow, indefinite []string) {
+	defTitles := make(map[string]string)
+	for _, d := range ef.Definitions {
+		title := d.Alert
+		if title == "" {
+			title = d.Name
+		}
+		defTitles[d.DefinitionID] = title
+	}
+
+	for _, f := range ef.Findings {
+		if f.Analyst == nil {
+			continue
+		}
+		if entities.CanonicalAnalystStatus(f.Analyst.Status) != "accepted" {
+			continue
+		}
+		raw := strings.TrimSpace(f.Analyst.AcceptedUntil)
+		if raw == "" {
+			indefinite = append(indefinite, f.FindingID)
+			continue
+		}
+		t, err := time.Parse(time.RFC3339, raw)
+		if err != nil {
+			// Unparseable date: surface it for review; treat as expired.
+			expired = append(expired, expiredRow{
+				FindingID:     f.FindingID,
+				RuleTitle:     defTitles[f.DefinitionID],
+				Severity:      f.Risk,
+				Domain:        domainFromURL(f.URL),
+				Owner:         strings.TrimSpace(f.Analyst.Owner),
+				AcceptedUntil: raw + " (unparseable)",
+				ExpiredAgo:    "unknown",
+				Notes:         strings.TrimSpace(f.Analyst.Notes),
+			})
+			continue
+		}
+		if t.Before(now) {
+			expired = append(expired, expiredRow{
+				FindingID:     f.FindingID,
+				RuleTitle:     defTitles[f.DefinitionID],
+				Severity:      f.Risk,
+				Domain:        domainFromURL(f.URL),
+				Owner:         strings.TrimSpace(f.Analyst.Owner),
+				AcceptedUntil: raw,
+				ExpiredAgo:    humanDuration(now.Sub(t)),
+				Notes:         strings.TrimSpace(f.Analyst.Notes),
+			})
+		}
+	}
+
+	sort.SliceStable(expired, func(i, j int) bool {
+		ti, _ := time.Parse(time.RFC3339, expired[i].AcceptedUntil)
+		tj, _ := time.Parse(time.RFC3339, expired[j].AcceptedUntil)
+		if !ti.Equal(tj) {
+			return ti.Before(tj)
+		}
+		return expired[i].FindingID < expired[j].FindingID
+	})
+
+	return expired, indefinite
+}
+
+// humanDuration formats a duration as a compact string (e.g. "3d", "2mo", "1y").
+func humanDuration(d time.Duration) string {
+	days := int(d.Hours()) / 24
+	switch {
+	case days >= 365:
+		return fmt.Sprintf("%dy", days/365)
+	case days >= 30:
+		return fmt.Sprintf("%dmo", days/30)
+	case days >= 1:
+		return fmt.Sprintf("%dd", days)
+	default:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	}
+}
+
+func runExpiredCommand(args []string) {
+	fs := flag.NewFlagSet("expired", flag.ExitOnError)
+	var entitiesIn, format, outPath string
+	fs.StringVar(&entitiesIn, "entities-in", "", "Entities JSON input file (required)")
+	fs.StringVar(&format, "format", "csv", "Output format: csv|json")
+	fs.StringVar(&outPath, "out", "-", "Output file path; use \"-\" or omit for stdout")
+	if err := fs.Parse(args); err != nil {
+		fmt.Fprintf(os.Stderr, "expired: %v\n", err)
+		os.Exit(1)
+	}
+	entitiesIn = strings.TrimSpace(entitiesIn)
+	if entitiesIn == "" {
+		fmt.Fprintln(os.Stderr, "expired: -entities-in is required")
+		fs.Usage()
+		os.Exit(1)
+	}
+
+	art, err := runartifact.ReadFlexible(entitiesIn)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "expired: read %q: %v\n", entitiesIn, err)
+		os.Exit(1)
+	}
+
+	rows, indefinite := buildExpiredRows(art.Entities, time.Now().UTC())
+	for _, fid := range indefinite {
+		fmt.Fprintf(os.Stderr, "[warn] %s: status=accepted with no acceptedUntil (permanent acceptance — consider adding an expiry date)\n", fid)
+	}
+
+	var out []byte
+	switch strings.ToLower(strings.TrimSpace(format)) {
+	case "json":
+		out, err = json.MarshalIndent(rows, "", "  ")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "expired: encode json: %v\n", err)
+			os.Exit(1)
+		}
+		out = append(out, '\n')
+	default: // csv
+		var sb strings.Builder
+		w := csv.NewWriter(&sb)
+		_ = w.Write([]string{"finding_id", "rule_title", "severity", "domain", "owner", "accepted_until", "expired_ago", "notes"})
+		for _, r := range rows {
+			_ = w.Write([]string{r.FindingID, r.RuleTitle, r.Severity, r.Domain, r.Owner, r.AcceptedUntil, r.ExpiredAgo, r.Notes})
+		}
+		w.Flush()
+		out = []byte(sb.String())
+	}
+
+	outPath = strings.TrimSpace(outPath)
+	if outPath == "" || outPath == "-" {
+		os.Stdout.Write(out)
+	} else {
+		if werr := os.WriteFile(outPath, out, 0o644); werr != nil {
+			fmt.Fprintf(os.Stderr, "expired: write %q: %v\n", outPath, werr)
+			os.Exit(1)
+		}
+	}
+
+	fmt.Fprintf(os.Stderr, "Acceptance expired: %d finding(s) (+ %d indefinite warning(s))\n",
+		len(rows), len(indefinite))
+}

--- a/zap-kb/cmd/zap-kb/expired_cmd_test.go
+++ b/zap-kb/cmd/zap-kb/expired_cmd_test.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Warlockobama/DevSecOpsKB/zap-kb/internal/entities"
+)
+
+func mustParseRFC3339(s string) time.Time {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}
+
+func acceptedFinding(id, acceptedUntil string) entities.Finding {
+	a := &entities.Analyst{Status: "accepted", AcceptedUntil: acceptedUntil}
+	return entities.Finding{FindingID: id, Risk: "medium", Analyst: a}
+}
+
+func TestBuildExpiredRows_Empty(t *testing.T) {
+	ef := entities.EntitiesFile{}
+	now := mustParseRFC3339("2026-04-24T00:00:00Z")
+	rows, indef := buildExpiredRows(ef, now)
+	if len(rows) != 0 {
+		t.Errorf("want 0 rows, got %d", len(rows))
+	}
+	if len(indef) != 0 {
+		t.Errorf("want 0 indefinite, got %d", len(indef))
+	}
+}
+
+func TestBuildExpiredRows_ExpiredFindingIncluded(t *testing.T) {
+	ef := entities.EntitiesFile{
+		Findings: []entities.Finding{
+			acceptedFinding("f1", "2026-01-01T00:00:00Z"), // 113 days before now
+		},
+	}
+	now := mustParseRFC3339("2026-04-24T00:00:00Z")
+	rows, indef := buildExpiredRows(ef, now)
+	if len(rows) != 1 {
+		t.Fatalf("want 1 expired row, got %d", len(rows))
+	}
+	if rows[0].FindingID != "f1" {
+		t.Errorf("FindingID: want f1, got %s", rows[0].FindingID)
+	}
+	if rows[0].ExpiredAgo == "" {
+		t.Error("ExpiredAgo should be non-empty")
+	}
+	if len(indef) != 0 {
+		t.Errorf("want 0 indefinite, got %d", len(indef))
+	}
+}
+
+func TestBuildExpiredRows_NotYetExpiredExcluded(t *testing.T) {
+	ef := entities.EntitiesFile{
+		Findings: []entities.Finding{
+			acceptedFinding("f1", "2026-12-31T00:00:00Z"), // future
+		},
+	}
+	now := mustParseRFC3339("2026-04-24T00:00:00Z")
+	rows, _ := buildExpiredRows(ef, now)
+	if len(rows) != 0 {
+		t.Errorf("non-expired finding must not appear, got %d rows", len(rows))
+	}
+}
+
+func TestBuildExpiredRows_NoAcceptedUntilGoesToIndefinite(t *testing.T) {
+	ef := entities.EntitiesFile{
+		Findings: []entities.Finding{
+			acceptedFinding("f1", ""), // no expiry
+		},
+	}
+	now := mustParseRFC3339("2026-04-24T00:00:00Z")
+	rows, indef := buildExpiredRows(ef, now)
+	if len(rows) != 0 {
+		t.Errorf("indefinite acceptance must not appear in expired list, got %d rows", len(rows))
+	}
+	if len(indef) != 1 || indef[0] != "f1" {
+		t.Errorf("want [f1] indefinite, got %v", indef)
+	}
+}
+
+func TestBuildExpiredRows_NonAcceptedIgnored(t *testing.T) {
+	ef := entities.EntitiesFile{
+		Findings: []entities.Finding{
+			{FindingID: "f1", Analyst: &entities.Analyst{Status: "open", AcceptedUntil: "2020-01-01T00:00:00Z"}},
+			{FindingID: "f2", Analyst: &entities.Analyst{Status: "fp", AcceptedUntil: "2020-01-01T00:00:00Z"}},
+		},
+	}
+	now := mustParseRFC3339("2026-04-24T00:00:00Z")
+	rows, indef := buildExpiredRows(ef, now)
+	if len(rows) != 0 || len(indef) != 0 {
+		t.Errorf("non-accepted findings must be ignored: rows=%d indef=%d", len(rows), len(indef))
+	}
+}
+
+func TestBuildExpiredRows_SortedMostOverdueFirst(t *testing.T) {
+	ef := entities.EntitiesFile{
+		Findings: []entities.Finding{
+			acceptedFinding("f-recent", "2026-04-01T00:00:00Z"),  // 23 days ago
+			acceptedFinding("f-oldest", "2025-01-01T00:00:00Z"),  // 1+ year ago
+			acceptedFinding("f-middle", "2026-02-01T00:00:00Z"),  // ~82 days ago
+		},
+	}
+	now := mustParseRFC3339("2026-04-24T00:00:00Z")
+	rows, _ := buildExpiredRows(ef, now)
+	if len(rows) != 3 {
+		t.Fatalf("want 3 rows, got %d", len(rows))
+	}
+	if rows[0].FindingID != "f-oldest" {
+		t.Errorf("first row should be most overdue (f-oldest), got %s", rows[0].FindingID)
+	}
+	if rows[2].FindingID != "f-recent" {
+		t.Errorf("last row should be least overdue (f-recent), got %s", rows[2].FindingID)
+	}
+}
+
+func TestBuildExpiredRows_RuleTitleFromDefinition(t *testing.T) {
+	ef := entities.EntitiesFile{
+		Definitions: []entities.Definition{
+			{DefinitionID: "def-1", Alert: "SQL Injection"},
+		},
+		Findings: []entities.Finding{
+			{FindingID: "f1", DefinitionID: "def-1",
+				Analyst: &entities.Analyst{Status: "accepted", AcceptedUntil: "2020-01-01T00:00:00Z"}},
+		},
+	}
+	now := mustParseRFC3339("2026-04-24T00:00:00Z")
+	rows, _ := buildExpiredRows(ef, now)
+	if len(rows) != 1 {
+		t.Fatalf("want 1 row, got %d", len(rows))
+	}
+	if rows[0].RuleTitle != "SQL Injection" {
+		t.Errorf("RuleTitle: want SQL Injection, got %q", rows[0].RuleTitle)
+	}
+}
+
+func TestHumanDuration(t *testing.T) {
+	cases := []struct {
+		d    time.Duration
+		want string
+	}{
+		{2 * time.Hour, "2h"},
+		{25 * time.Hour, "1d"},
+		{32 * 24 * time.Hour, "1mo"},
+		{400 * 24 * time.Hour, "1y"},
+	}
+	for _, tc := range cases {
+		got := humanDuration(tc.d)
+		if got != tc.want {
+			t.Errorf("humanDuration(%v) = %q, want %q", tc.d, got, tc.want)
+		}
+	}
+}

--- a/zap-kb/cmd/zap-kb/main.go
+++ b/zap-kb/cmd/zap-kb/main.go
@@ -181,6 +181,10 @@ func main() {
 		runOnboardCommand(os.Args[2:])
 		return
 	}
+	if len(os.Args) > 1 && os.Args[1] == "expired" {
+		runExpiredCommand(os.Args[2:])
+		return
+	}
 
 	flag.Parse()
 

--- a/zap-kb/cmd/zap-kb/onboard_cmd.go
+++ b/zap-kb/cmd/zap-kb/onboard_cmd.go
@@ -56,6 +56,10 @@ func runOnboardCommand(args []string) {
 	}
 
 	if web {
+		if port < 0 || port > 65535 {
+			fmt.Fprintf(os.Stderr, "onboard: -port must be 0 (OS-assigned) or 1..65535, got %d\n", port)
+			os.Exit(1)
+		}
 		res, werr := webonboard.Run(start, path, port)
 		if werr != nil {
 			fmt.Fprintf(os.Stderr, "onboard: %v\n", werr)

--- a/zap-kb/cmd/zap-kb/onboard_cmd.go
+++ b/zap-kb/cmd/zap-kb/onboard_cmd.go
@@ -1,9 +1,15 @@
 package main
 
-// onboard sub-command: launches the Bubble Tea triage-policy onboarding TUI
-// (epic #71 slice 1c-iii). Pre-loads the existing policy (or defaults when
-// none) so the user's previous answers are shown as starting values and they
-// can walk through again to adjust.
+// onboard sub-command: launches the triage-policy onboarding UI.
+//
+// Two modes (epic #71 slices 1c-iii / 1c-iv):
+//
+//	zap-kb onboard              — Bubble Tea terminal wizard (default)
+//	zap-kb onboard -web         — local HTTP server, auto-opens browser
+//	zap-kb onboard -web -port N — same, on a specific port (0 = OS-assigned)
+//
+// Both modes pre-fill from the existing triage-policy.yaml (or built-in
+// defaults) so re-running edits rather than starting blank.
 
 import (
 	"flag"
@@ -13,12 +19,19 @@ import (
 
 	"github.com/Warlockobama/DevSecOpsKB/zap-kb/internal/config"
 	"github.com/Warlockobama/DevSecOpsKB/zap-kb/internal/tui/onboard"
+	webonboard "github.com/Warlockobama/DevSecOpsKB/zap-kb/internal/webui/onboard"
 )
 
 func runOnboardCommand(args []string) {
 	fs := flag.NewFlagSet("onboard", flag.ExitOnError)
-	var path string
+	var (
+		path string
+		web  bool
+		port int
+	)
 	fs.StringVar(&path, "path", "", "Where to write the YAML (default: ./triage-policy.yaml)")
+	fs.BoolVar(&web, "web", false, "Launch a browser-based wizard instead of the terminal TUI")
+	fs.IntVar(&port, "port", 0, "Port for the web UI (0 = OS-assigned; ignored without -web)")
 	if err := fs.Parse(args); err != nil {
 		fmt.Fprintf(os.Stderr, "onboard: %v\n", err)
 		os.Exit(1)
@@ -41,6 +54,21 @@ func runOnboardCommand(args []string) {
 	if src != "" {
 		fmt.Fprintf(os.Stderr, "[info] pre-filling from %s\n", src)
 	}
+
+	if web {
+		res, werr := webonboard.Run(start, path, port)
+		if werr != nil {
+			fmt.Fprintf(os.Stderr, "onboard: %v\n", werr)
+			os.Exit(1)
+		}
+		if !res.Saved {
+			fmt.Fprintln(os.Stderr, "Onboarding exited without saving.")
+			return
+		}
+		fmt.Printf("Wrote triage policy to %s\n", res.SavedTo)
+		return
+	}
+
 	final, err := onboard.Run(start, path)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "onboard: %v\n", err)

--- a/zap-kb/internal/output/confluence/exporter.go
+++ b/zap-kb/internal/output/confluence/exporter.go
@@ -2379,6 +2379,15 @@ func prependFindingProperties(storageBody string, f *entities.Finding, ei *entit
 			}
 			props = append(props, [2]string{notesLabel, escapeHTML(f.Analyst.Notes)})
 		}
+		if entities.CanonicalAnalystStatus(strings.TrimSpace(f.Analyst.Status)) == "accepted" {
+			if au := strings.TrimSpace(f.Analyst.AcceptedUntil); au != "" {
+				val := escapeHTML(au)
+				if t, err := time.Parse(time.RFC3339, au); err == nil && t.Before(time.Now().UTC()) {
+					val += ` <strong>(expired)</strong>`
+				}
+				props = append(props, [2]string{"Accepted Until", val})
+			}
+		}
 	}
 	// Source tool (derived from definition tags: "nuclei", "zap", "burp", etc.)
 	if src := sourceToolFromDef(def); src != "" {
@@ -2413,10 +2422,52 @@ func prependFindingProperties(storageBody string, f *entities.Finding, ei *entit
 	// vulnerability context and fix guidance without leaving the finding page.
 	defSection := buildDefContextSection(def)
 
-	// Page order: properties → recurrence warning → changelog → analyst log
-	// (do work here) → Jira workflow → suppression → description/solution →
-	// rollup/occurrences/traffic
-	return pagePropertiesMacro(props) + recurrenceSection + changelogSection + analystLogSection + workflowSection + suppressionSection + defSection + storageBody
+	// History timeline — collapsible expand showing analyst triage audit trail
+	// (#62). Placed before the analyst log form so analysts can reference past
+	// decisions while writing their current entry.
+	historySection := ""
+	if f.Analyst != nil {
+		historySection = buildHistoryTimelineSection(f.Analyst.History)
+	}
+
+	// Page order: properties → recurrence warning → changelog → history timeline
+	// → analyst log (do work here) → Jira workflow → suppression →
+	// description/solution → rollup/occurrences/traffic
+	return pagePropertiesMacro(props) + recurrenceSection + changelogSection + historySection + analystLogSection + workflowSection + suppressionSection + defSection + storageBody
+}
+
+// buildHistoryTimelineSection renders the analyst triage audit trail
+// (Analyst.History) as a collapsible Confluence expand macro. Empty history
+// renders an explicit "No triage history recorded" note so the section is
+// never a blank accordion — requirement from epic #71 slice 2 (#62).
+func buildHistoryTimelineSection(history []entities.AnalystHistoryEntry) string {
+	var b strings.Builder
+	b.WriteString(`<ac:structured-macro ac:name="expand">`)
+	title := "Triage History"
+	if len(history) > 0 {
+		title = fmt.Sprintf("Triage History (%d entries)", len(history))
+	}
+	b.WriteString(`<ac:parameter ac:name="title">` + escapeHTML(title) + `</ac:parameter>`)
+	b.WriteString(`<ac:rich-text-body>`)
+	if len(history) == 0 {
+		b.WriteString(`<p>No triage history recorded.</p>`)
+	} else {
+		b.WriteString(`<table><tbody>`)
+		b.WriteString(`<tr><th>Date</th><th>Status</th><th>Previous</th><th>Owner</th><th>Scan</th><th>Notes</th></tr>`)
+		for _, e := range history {
+			b.WriteString(`<tr>`)
+			b.WriteString(`<td>` + escapeHTML(e.UpdatedAt) + `</td>`)
+			b.WriteString(`<td>` + escapeHTML(e.Status) + `</td>`)
+			b.WriteString(`<td>` + escapeHTML(e.PriorStatus) + `</td>`)
+			b.WriteString(`<td>` + escapeHTML(e.Owner) + `</td>`)
+			b.WriteString(`<td><code>` + escapeHTML(e.ScanLabel) + `</code></td>`)
+			b.WriteString(`<td>` + escapeHTML(e.Notes) + `</td>`)
+			b.WriteString(`</tr>`)
+		}
+		b.WriteString(`</tbody></table>`)
+	}
+	b.WriteString(`</ac:rich-text-body></ac:structured-macro>`)
+	return b.String()
 }
 
 // buildRecurrenceSection renders an info panel warning when Merge() detected that

--- a/zap-kb/internal/output/confluence/history_test.go
+++ b/zap-kb/internal/output/confluence/history_test.go
@@ -1,0 +1,194 @@
+package confluence
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Warlockobama/DevSecOpsKB/zap-kb/internal/entities"
+)
+
+// TestBuildHistoryTimelineSection_Empty: no history entries must render the
+// explicit empty-state message, not a blank table — epic #71 slice 2 (#62).
+func TestBuildHistoryTimelineSection_Empty(t *testing.T) {
+	out := buildHistoryTimelineSection(nil)
+	if !strings.Contains(out, "No triage history recorded") {
+		t.Errorf("empty history must render empty-state message, got:\n%s", out)
+	}
+	if strings.Contains(out, "<table>") {
+		t.Error("empty history must not render a table")
+	}
+	if !strings.Contains(out, `ac:name="expand"`) {
+		t.Error("section must be wrapped in an expand macro")
+	}
+}
+
+func TestBuildHistoryTimelineSection_EmptySlice(t *testing.T) {
+	out := buildHistoryTimelineSection([]entities.AnalystHistoryEntry{})
+	if !strings.Contains(out, "No triage history recorded") {
+		t.Errorf("empty slice must render empty-state message, got:\n%s", out)
+	}
+}
+
+// TestBuildHistoryTimelineSection_WithEntries: populated history renders a
+// table with one row per entry and the expand title reflects the count.
+func TestBuildHistoryTimelineSection_WithEntries(t *testing.T) {
+	history := []entities.AnalystHistoryEntry{
+		{
+			EntryID:     "e1",
+			Status:      "fp",
+			PriorStatus: "open",
+			Owner:       "alice",
+			ScanLabel:   "prod-20260101",
+			Notes:       "Confirmed false positive on static asset",
+			UpdatedAt:   "2026-01-01T10:00:00Z",
+		},
+		{
+			EntryID:     "e2",
+			Status:      "open",
+			PriorStatus: "fp",
+			Owner:       "",
+			ScanLabel:   "prod-20260410",
+			Notes:       "auto-reopened: recurrence in scan prod-20260410",
+			UpdatedAt:   "2026-04-10T08:00:00Z",
+		},
+	}
+	out := buildHistoryTimelineSection(history)
+
+	if !strings.Contains(out, "Triage History (2 entries)") {
+		t.Errorf("title should say 2 entries, got:\n%s", out)
+	}
+	if !strings.Contains(out, "<table>") {
+		t.Error("should render a table with entries")
+	}
+	if strings.Contains(out, "No triage history recorded") {
+		t.Error("non-empty history must not render empty-state message")
+	}
+	// All entry fields should appear in the output.
+	for _, needle := range []string{
+		"fp", "open", "alice", "prod-20260101", "Confirmed false positive",
+		"auto-reopened", "prod-20260410", "2026-01-01T10:00:00Z",
+	} {
+		if !strings.Contains(out, needle) {
+			t.Errorf("expected %q in history output, got:\n%s", needle, out)
+		}
+	}
+}
+
+// TestBuildHistoryTimelineSection_HTMLEscaped: entry fields with special HTML
+// characters must be escaped so they don't break Confluence storage XML.
+func TestBuildHistoryTimelineSection_HTMLEscaped(t *testing.T) {
+	history := []entities.AnalystHistoryEntry{
+		{Status: "fp", Notes: `<script>alert("xss")</script>`, UpdatedAt: "2026-01-01T00:00:00Z"},
+	}
+	out := buildHistoryTimelineSection(history)
+	if strings.Contains(out, "<script>") {
+		t.Error("HTML in history entries must be escaped")
+	}
+	if !strings.Contains(out, "&lt;script&gt;") {
+		t.Error("HTML should be entity-escaped in output")
+	}
+}
+
+// TestPrependFindingProperties_AcceptedUntilShown: when a finding has
+// status=accepted and a future acceptedUntil, the property row is rendered
+// without an "(expired)" suffix.
+func TestPrependFindingProperties_AcceptedUntilShown(t *testing.T) {
+	f := &entities.Finding{
+		FindingID: "f1",
+		Risk:      "medium",
+		URL:       "https://example.com/api",
+		Analyst: &entities.Analyst{
+			Status:        "accepted",
+			AcceptedUntil: "2099-12-31T00:00:00Z", // far future
+			Notes:         "Risk accepted by security manager",
+		},
+	}
+	ei := &entityIndex{
+		findingObs:   map[string]obsRange{},
+		findingScans: map[string][]string{},
+	}
+	out := prependFindingProperties("body", f, ei, "", nil, nil, "", "", "")
+	if !strings.Contains(out, "Accepted Until") {
+		t.Errorf("accepted finding with future acceptedUntil must show 'Accepted Until' property, got:\n%s", out[:min(500, len(out))])
+	}
+	if strings.Contains(out, "(expired)") {
+		t.Error("future acceptedUntil must not show (expired)")
+	}
+}
+
+// TestPrependFindingProperties_AcceptedUntilExpiredLabel: when acceptedUntil
+// is in the past, the "(expired)" label must appear on the property value.
+func TestPrependFindingProperties_AcceptedUntilExpiredLabel(t *testing.T) {
+	f := &entities.Finding{
+		FindingID: "f1",
+		Risk:      "medium",
+		URL:       "https://example.com/api",
+		Analyst: &entities.Analyst{
+			Status:        "accepted",
+			AcceptedUntil: "2020-01-01T00:00:00Z", // past
+			Notes:         "Risk accepted",
+		},
+	}
+	ei := &entityIndex{
+		findingObs:   map[string]obsRange{},
+		findingScans: map[string][]string{},
+	}
+	out := prependFindingProperties("body", f, ei, "", nil, nil, "", "", "")
+	if !strings.Contains(out, "Accepted Until") {
+		t.Errorf("must show 'Accepted Until' property, got snippet: %q", out[:min(300, len(out))])
+	}
+	if !strings.Contains(out, "(expired)") {
+		t.Errorf("past acceptedUntil must be labelled (expired), got snippet: %q", out[:min(300, len(out))])
+	}
+}
+
+// TestPrependFindingProperties_AcceptedUntilHiddenWhenNotAccepted: the
+// "Accepted Until" property must not appear for non-accepted statuses.
+func TestPrependFindingProperties_AcceptedUntilHiddenWhenNotAccepted(t *testing.T) {
+	f := &entities.Finding{
+		FindingID: "f1",
+		Risk:      "medium",
+		URL:       "https://example.com/api",
+		Analyst: &entities.Analyst{
+			Status:        "open",
+			AcceptedUntil: "2099-12-31T00:00:00Z",
+		},
+	}
+	ei := &entityIndex{
+		findingObs:   map[string]obsRange{},
+		findingScans: map[string][]string{},
+	}
+	out := prependFindingProperties("body", f, ei, "", nil, nil, "", "", "")
+	if strings.Contains(out, "Accepted Until") {
+		t.Error("'Accepted Until' must not appear for non-accepted findings")
+	}
+}
+
+// TestPrependFindingProperties_HistorySectionPresent: the expand macro for
+// triage history must always be injected on a finding page (even when empty).
+func TestPrependFindingProperties_HistorySectionPresent(t *testing.T) {
+	f := &entities.Finding{
+		FindingID: "f1",
+		Risk:      "low",
+		URL:       "https://example.com/",
+		Analyst:   &entities.Analyst{Status: "open", History: nil},
+	}
+	ei := &entityIndex{
+		findingObs:   map[string]obsRange{},
+		findingScans: map[string][]string{},
+	}
+	out := prependFindingProperties("body", f, ei, "", nil, nil, "", "", "")
+	if !strings.Contains(out, `ac:name="expand"`) {
+		t.Error("finding page must include the history expand macro")
+	}
+	if !strings.Contains(out, "No triage history recorded") {
+		t.Error("finding with no history must show empty-state message")
+	}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/zap-kb/internal/webui/onboard/handler.go
+++ b/zap-kb/internal/webui/onboard/handler.go
@@ -262,7 +262,9 @@ func NewHandler(start config.TriagePolicy, outPath string, results chan<- Result
 		}
 		p, parseErr := parseForm(r)
 		if parseErr != nil {
-			renderForm(w, start, outPath, parseErr.Error())
+			// Re-render with the parsed policy so the user keeps their input
+			// and only needs to fix the failing field.
+			renderForm(w, p, outPath, parseErr.Error())
 			return
 		}
 		if err := config.WritePolicy(outPath, p); err != nil {
@@ -306,7 +308,8 @@ func Run(start config.TriagePolicy, outPath string, port int) (Result, error) {
 	fmt.Printf("Triage policy onboarding: %s\n", addr)
 	openBrowser(addr)
 
-	return <-results, nil
+	res := <-results
+	return res, res.Err
 }
 
 // openBrowser attempts to open url in the system default browser.

--- a/zap-kb/internal/webui/onboard/handler.go
+++ b/zap-kb/internal/webui/onboard/handler.go
@@ -1,0 +1,326 @@
+// Package onboard implements a local-HTTP-server onboarding UI for
+// triage-policy.yaml — the browser-based mirror of internal/tui/onboard.
+// Slice 1c-iv of epic #71.
+//
+// Usage (via the CLI):
+//
+//	zap-kb onboard -web [-port 7979] [-path ./triage-policy.yaml]
+//
+// The server binds to 127.0.0.1 only, picks an OS-assigned port when -port is
+// 0, prints the URL, attempts to open the system browser, then blocks until
+// the user saves or cancels. One save closes the server — it is not a
+// persistent daemon.
+package onboard
+
+import (
+	"context"
+	"fmt"
+	"html/template"
+	"net"
+	"net/http"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/Warlockobama/DevSecOpsKB/zap-kb/internal/config"
+)
+
+// Result is sent on the channel returned by Handler once the user saves or
+// cancels. Err is non-nil only when the HTTP server itself fails; a user
+// cancellation sets Saved=false with Err=nil.
+type Result struct {
+	Saved   bool
+	SavedTo string
+	Err     error
+}
+
+// fieldData is the per-knob view model passed to the HTML template.
+type fieldData struct {
+	Title   string
+	Para    string
+	Name    string
+	IsBool  bool
+	BoolVal bool
+	IntVal  int
+}
+
+// pageData is the top-level template context for the form page.
+type pageData struct {
+	Path   string
+	ErrMsg string
+	Fields []fieldData
+}
+
+func buildFields(p config.TriagePolicy) []fieldData {
+	return []fieldData{
+		{
+			Title: "Auto-reopen on recurrence",
+			Para: "When enabled, findings you've marked false-positive (fp) or fixed are\n" +
+				"automatically flipped back to \"open\" if a later scan rediscovers them.\n" +
+				"An audit trail entry is appended so you can see why.\n\n" +
+				"Disable only if you want recurrence to be advisory and re-triage by hand.\n" +
+				"\"accepted\" findings are NEVER auto-reopened (they're time-bounded by\n" +
+				"acceptedUntil instead).",
+			Name:    "autoReopenOnRecurrence",
+			IsBool:  true,
+			BoolVal: p.AutoReopenOnRecurrence,
+		},
+		{
+			Title: "False-positive auto-suppression threshold",
+			Para: "How many \"analyst-said-fp → detection-found-it-again\" cycles to tolerate\n" +
+				"on a single finding before zap-kb auto-suppresses it. Each cycle is one\n" +
+				"history entry. After this many cycles, the finding stops appearing in\n" +
+				"triage queues until the suppression expires.\n\n" +
+				"Recommended: 3. Set 0 to disable auto-suppression entirely.",
+			Name:   "findingFPSuppressionThreshold",
+			IntVal: p.FindingFPSuppressionThreshold,
+		},
+		{
+			Title: "Auto-suppression expiry (days)",
+			Para: "How long an auto-written suppression lasts before the finding returns to\n" +
+				"the triage queue for reconfirmation. Bounds the \"hide and forget\" risk\n" +
+				"so a noisy finding can't disappear forever if the underlying app code\n" +
+				"changes.\n\n" +
+				"Recommended: 90 days.",
+			Name:   "findingFPSuppressionExpiryDays",
+			IntVal: p.FindingFPSuppressionExpiryDays,
+		},
+		{
+			Title: "Rule tune-scan threshold",
+			Para: "Aggregate fp count across every finding sharing a detection rule (same\n" +
+				"pluginId). When the rule-wide total crosses this number, the detection\n" +
+				"definition is tagged \"tune-scan\" so security engineering knows it's a\n" +
+				"high-noise rule worth retuning.\n\n" +
+				"Recommended: 5. Set 0 to disable rule-level tagging.",
+			Name:   "ruleTuneScanThreshold",
+			IntVal: p.RuleTuneScanThreshold,
+		},
+		{
+			Title: "Accepted-risk default expiry (days)",
+			Para: "When an analyst marks a finding \"accepted\" without specifying their own\n" +
+				"acceptedUntil date, zap-kb stamps an expiry this many days out. The\n" +
+				"acceptance-expired report (slice 2) flags findings whose acceptance has\n" +
+				"lapsed so risk decisions get periodically revisited.\n\n" +
+				"Recommended: 180 days.",
+			Name:   "acceptedDefaultExpiryDays",
+			IntVal: p.AcceptedDefaultExpiryDays,
+		},
+	}
+}
+
+var formTmpl = template.Must(template.New("form").Parse(`<!DOCTYPE html>
+<html lang="en"><head>
+  <meta charset="utf-8">
+  <title>zap-kb triage policy onboarding</title>
+  <style>
+    body{font-family:system-ui,sans-serif;max-width:700px;margin:2rem auto;padding:0 1rem;color:#222}
+    h1{color:#1a1a2e;margin-bottom:.25rem}
+    .intro{color:#555;margin-bottom:1.5rem}
+    .path{font-family:monospace;font-size:.85rem;color:#555;margin-bottom:1.5rem}
+    .field{margin:1.5rem 0;padding:1rem 1.25rem;border:1px solid #ddd;border-radius:6px;background:#fafafa}
+    .field h2{margin:.0 0 .5rem;font-size:1rem;color:#111}
+    .field p{color:#555;font-size:.875rem;white-space:pre-wrap;margin:.5rem 0 1rem}
+    label{display:flex;align-items:center;gap:.5rem;font-weight:500;font-size:.95rem}
+    input[type=number]{width:9ch;padding:.3rem .4rem;font-size:1rem;border:1px solid #aaa;border-radius:4px}
+    input[type=checkbox]{width:1rem;height:1rem;cursor:pointer}
+    .error{color:#b91c1c;background:#fef2f2;border:1px solid #fca5a5;padding:.75rem 1rem;border-radius:4px;margin:1rem 0}
+    .actions{display:flex;gap:1rem;margin-top:2rem;padding-top:1rem;border-top:1px solid #eee}
+    button{padding:.6rem 1.5rem;border:none;border-radius:4px;font-size:1rem;cursor:pointer;font-weight:500}
+    .btn-save{background:#2563eb;color:#fff}.btn-save:hover{background:#1d4ed8}
+    .btn-cancel{background:#e5e7eb;color:#374151}.btn-cancel:hover{background:#d1d5db}
+  </style>
+</head>
+<body>
+  <h1>zap-kb triage policy onboarding</h1>
+  <p class="intro">Configure the operator-tunable knobs that control how zap-kb auto-triages
+recurring findings. Values are pre-filled from your current policy (or built-in defaults).
+Click <strong>Save policy</strong> to write the YAML and close this server.</p>
+  <p class="path">Writing to: <code>{{.Path}}</code></p>
+  {{if .ErrMsg}}<div class="error">{{.ErrMsg}}</div>{{end}}
+  <form method="POST" action="/">
+    {{range .Fields}}
+    <div class="field">
+      <h2>{{.Title}}</h2>
+      <p>{{.Para}}</p>
+      {{if .IsBool}}
+      <label>
+        <input type="checkbox" name="{{.Name}}" value="true"{{if .BoolVal}} checked{{end}}>
+        Enabled
+      </label>
+      {{else}}
+      <label>
+        Value: <input type="number" name="{{.Name}}" value="{{.IntVal}}" min="0" required>
+      </label>
+      {{end}}
+    </div>
+    {{end}}
+    <div class="actions">
+      <button type="submit" class="btn-save">Save policy</button>
+      <button type="button" class="btn-cancel" onclick="window.location='/cancel'">Cancel</button>
+    </div>
+  </form>
+</body></html>
+`))
+
+var doneTmpl = template.Must(template.New("done").Parse(`<!DOCTYPE html>
+<html lang="en"><head>
+  <meta charset="utf-8">
+  <title>zap-kb — policy saved</title>
+  <style>
+    body{font-family:system-ui,sans-serif;max-width:500px;margin:4rem auto;padding:0 1rem;color:#222}
+    .ok{color:#15803d;font-size:1.1rem;font-weight:600}
+    code{font-family:monospace;background:#f1f5f9;padding:.1rem .3rem;border-radius:3px}
+  </style>
+</head>
+<body>
+  <p class="ok">✓ Triage policy saved to <code>{{.}}</code></p>
+  <p>zap-kb will pick this up automatically on the next run.<br>
+  Run <code>zap-kb config show</code> to confirm.<br><br>
+  You can close this tab.</p>
+</body></html>
+`))
+
+var cancelTmpl = template.Must(template.New("cancel").Parse(`<!DOCTYPE html>
+<html lang="en"><head>
+  <meta charset="utf-8"><title>zap-kb — cancelled</title>
+  <style>body{font-family:system-ui,sans-serif;max-width:500px;margin:4rem auto;padding:0 1rem;color:#222}</style>
+</head>
+<body>
+  <p>Onboarding cancelled. No changes were written.</p>
+  <p>You can close this tab.</p>
+</body></html>
+`))
+
+func renderForm(w http.ResponseWriter, p config.TriagePolicy, outPath, errMsg string) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_ = formTmpl.Execute(w, pageData{
+		Path:   outPath,
+		ErrMsg: errMsg,
+		Fields: buildFields(p),
+	})
+}
+
+func renderDone(w http.ResponseWriter, outPath string) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_ = doneTmpl.Execute(w, outPath)
+}
+
+func renderCancel(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_ = cancelTmpl.Execute(w, nil)
+}
+
+func parseForm(r *http.Request) (config.TriagePolicy, error) {
+	var p config.TriagePolicy
+	p.AutoReopenOnRecurrence = r.FormValue("autoReopenOnRecurrence") == "true"
+
+	intFields := []struct {
+		name string
+		dest *int
+	}{
+		{"findingFPSuppressionThreshold", &p.FindingFPSuppressionThreshold},
+		{"findingFPSuppressionExpiryDays", &p.FindingFPSuppressionExpiryDays},
+		{"ruleTuneScanThreshold", &p.RuleTuneScanThreshold},
+		{"acceptedDefaultExpiryDays", &p.AcceptedDefaultExpiryDays},
+	}
+	for _, f := range intFields {
+		raw := strings.TrimSpace(r.FormValue(f.name))
+		v, err := strconv.Atoi(raw)
+		if err != nil || v < 0 {
+			return p, fmt.Errorf("%s: must be a non-negative integer (got %q)", f.name, raw)
+		}
+		*f.dest = v
+	}
+	return p, nil
+}
+
+// NewHandler returns an http.Handler for the onboarding web UI pre-filled
+// with start and writing to outPath on save. results receives exactly one
+// Result; shutdown is called (once, asynchronously) after it is sent.
+//
+// Exported for use with httptest.NewServer in tests.
+func NewHandler(start config.TriagePolicy, outPath string, results chan<- Result, shutdown func()) http.Handler {
+	mux := http.NewServeMux()
+	var once sync.Once
+	send := func(res Result) {
+		once.Do(func() {
+			results <- res
+			go shutdown()
+		})
+	}
+
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			renderForm(w, start, outPath, "")
+			return
+		}
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, "bad form data", http.StatusBadRequest)
+			return
+		}
+		p, parseErr := parseForm(r)
+		if parseErr != nil {
+			renderForm(w, start, outPath, parseErr.Error())
+			return
+		}
+		if err := config.WritePolicy(outPath, p); err != nil {
+			renderForm(w, p, outPath, "write failed: "+err.Error())
+			return
+		}
+		renderDone(w, outPath)
+		send(Result{Saved: true, SavedTo: outPath})
+	})
+
+	mux.HandleFunc("/cancel", func(w http.ResponseWriter, r *http.Request) {
+		renderCancel(w)
+		send(Result{})
+	})
+
+	return mux
+}
+
+// Run starts a local HTTP server on 127.0.0.1, attempts to open the system
+// browser, prints the URL to stdout, and blocks until the user saves or
+// cancels. port=0 lets the OS assign a free port.
+func Run(start config.TriagePolicy, outPath string, port int) (Result, error) {
+	ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		return Result{}, fmt.Errorf("listen: %w", err)
+	}
+	addr := fmt.Sprintf("http://127.0.0.1:%d", ln.Addr().(*net.TCPAddr).Port)
+
+	results := make(chan Result, 1)
+	srv := &http.Server{}
+	srv.Handler = NewHandler(start, outPath, results, func() {
+		_ = srv.Shutdown(context.Background())
+	})
+
+	go func() {
+		if err := srv.Serve(ln); err != nil && err != http.ErrServerClosed {
+			results <- Result{Err: err}
+		}
+	}()
+
+	fmt.Printf("Triage policy onboarding: %s\n", addr)
+	openBrowser(addr)
+
+	return <-results, nil
+}
+
+// openBrowser attempts to open url in the system default browser.
+// Failures are ignored — the URL is always printed to stdout so the user
+// can open it manually.
+func openBrowser(url string) {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", url)
+	case "windows":
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
+	default:
+		cmd = exec.Command("xdg-open", url)
+	}
+	_ = cmd.Start()
+}

--- a/zap-kb/internal/webui/onboard/handler_test.go
+++ b/zap-kb/internal/webui/onboard/handler_test.go
@@ -63,7 +63,15 @@ func TestHandler_GET_PreFillsDefaults(t *testing.T) {
 	}
 	// Default threshold=3 should appear as input value
 	if !strings.Contains(s, `value="3"`) {
-		t.Errorf("default FP threshold 3 should appear in form, body snippet: %q", s[strings.Index(s, "findingFP"):strings.Index(s, "findingFP")+200])
+		start := strings.Index(s, "findingFP")
+		if start < 0 {
+			start = 0
+		}
+		end := start + 200
+		if end > len(s) {
+			end = len(s)
+		}
+		t.Errorf("default FP threshold 3 should appear in form, body snippet: %q", s[start:end])
 	}
 }
 

--- a/zap-kb/internal/webui/onboard/handler_test.go
+++ b/zap-kb/internal/webui/onboard/handler_test.go
@@ -1,0 +1,263 @@
+package onboard
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Warlockobama/DevSecOpsKB/zap-kb/internal/config"
+)
+
+// newTestServer wires up a Handler against an httptest.Server. The results
+// channel and a no-op shutdown are injected so tests can observe outcomes
+// without starting a real listener or opening a browser.
+func newTestServer(t *testing.T, start config.TriagePolicy, outPath string) (*httptest.Server, chan Result) {
+	t.Helper()
+	results := make(chan Result, 1)
+	srv := httptest.NewServer(NewHandler(start, outPath, results, func() {}))
+	t.Cleanup(srv.Close)
+	return srv, results
+}
+
+func TestHandler_GET_RendersForm(t *testing.T) {
+	srv, _ := newTestServer(t, config.DefaultPolicy(), filepath.Join(t.TempDir(), "p.yaml"))
+	resp, err := http.Get(srv.URL + "/")
+	if err != nil {
+		t.Fatalf("GET /: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status: want 200, got %d", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	s := string(body)
+	if !strings.Contains(s, "triage policy onboarding") {
+		t.Error("form page should contain heading text")
+	}
+	if !strings.Contains(s, "autoReopenOnRecurrence") {
+		t.Error("form page should include autoReopenOnRecurrence field")
+	}
+	if !strings.Contains(s, "findingFPSuppressionThreshold") {
+		t.Error("form page should include findingFPSuppressionThreshold field")
+	}
+}
+
+func TestHandler_GET_PreFillsDefaults(t *testing.T) {
+	d := config.DefaultPolicy()
+	srv, _ := newTestServer(t, d, filepath.Join(t.TempDir(), "p.yaml"))
+	resp, err := http.Get(srv.URL + "/")
+	if err != nil {
+		t.Fatalf("GET /: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	s := string(body)
+	// Default AutoReopenOnRecurrence=true → checkbox should be checked
+	if !strings.Contains(s, "checked") {
+		t.Error("autoReopenOnRecurrence default=true should render checkbox as checked")
+	}
+	// Default threshold=3 should appear as input value
+	if !strings.Contains(s, `value="3"`) {
+		t.Errorf("default FP threshold 3 should appear in form, body snippet: %q", s[strings.Index(s, "findingFP"):strings.Index(s, "findingFP")+200])
+	}
+}
+
+func TestHandler_POST_ValidSavesAndSendsResult(t *testing.T) {
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "triage-policy.yaml")
+	srv, results := newTestServer(t, config.DefaultPolicy(), outPath)
+
+	form := url.Values{
+		"autoReopenOnRecurrence":         {"true"},
+		"findingFPSuppressionThreshold":  {"7"},
+		"findingFPSuppressionExpiryDays": {"45"},
+		"ruleTuneScanThreshold":          {"10"},
+		"acceptedDefaultExpiryDays":      {"365"},
+	}
+	resp, err := http.PostForm(srv.URL+"/", form)
+	if err != nil {
+		t.Fatalf("POST /: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status: want 200, got %d", resp.StatusCode)
+	}
+
+	// Result channel should have received a saved result.
+	select {
+	case res := <-results:
+		if !res.Saved {
+			t.Errorf("result.Saved: want true, got false (err=%v)", res.Err)
+		}
+		if res.SavedTo != outPath {
+			t.Errorf("result.SavedTo: want %q, got %q", outPath, res.SavedTo)
+		}
+	default:
+		t.Fatal("expected result on channel, got none")
+	}
+
+	// The YAML must have been written with the submitted values.
+	data, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read written YAML: %v", err)
+	}
+	s := string(data)
+	if !strings.Contains(s, "findingFPSuppressionThreshold: 7") {
+		t.Errorf("YAML should contain threshold 7, got:\n%s", s)
+	}
+	if !strings.Contains(s, "acceptedDefaultExpiryDays: 365") {
+		t.Errorf("YAML should contain expiry 365, got:\n%s", s)
+	}
+}
+
+func TestHandler_POST_ValidRoundTripsThroughLoadPolicy(t *testing.T) {
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "triage-policy.yaml")
+	srv, _ := newTestServer(t, config.DefaultPolicy(), outPath)
+
+	form := url.Values{
+		"autoReopenOnRecurrence":         {}, // absent = false
+		"findingFPSuppressionThreshold":  {"2"},
+		"findingFPSuppressionExpiryDays": {"60"},
+		"ruleTuneScanThreshold":          {"8"},
+		"acceptedDefaultExpiryDays":      {"120"},
+	}
+	resp, err := http.PostForm(srv.URL+"/", form)
+	if err != nil {
+		t.Fatalf("POST /: %v", err)
+	}
+	resp.Body.Close()
+
+	// Load through the real LoadPolicy to verify the round-trip.
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(t.TempDir(), ".config"))
+	t.Setenv("APPDATA", filepath.Join(t.TempDir(), "AppData", "Roaming"))
+	got, src, err := config.LoadPolicy(dir)
+	if err != nil {
+		t.Fatalf("LoadPolicy: %v", err)
+	}
+	if src != outPath {
+		t.Errorf("source: want %q, got %q", outPath, src)
+	}
+	want := config.TriagePolicy{
+		AutoReopenOnRecurrence:         false,
+		FindingFPSuppressionThreshold:  2,
+		FindingFPSuppressionExpiryDays: 60,
+		RuleTuneScanThreshold:          8,
+		AcceptedDefaultExpiryDays:      120,
+	}
+	if got != want {
+		t.Errorf("round-trip mismatch:\n  want %+v\n   got %+v", want, got)
+	}
+}
+
+func TestHandler_POST_InvalidIntShowsErrorAndStaysOnForm(t *testing.T) {
+	srv, results := newTestServer(t, config.DefaultPolicy(), filepath.Join(t.TempDir(), "p.yaml"))
+
+	form := url.Values{
+		"autoReopenOnRecurrence":         {"true"},
+		"findingFPSuppressionThreshold":  {"abc"}, // invalid
+		"findingFPSuppressionExpiryDays": {"90"},
+		"ruleTuneScanThreshold":          {"5"},
+		"acceptedDefaultExpiryDays":      {"180"},
+	}
+	resp, err := http.PostForm(srv.URL+"/", form)
+	if err != nil {
+		t.Fatalf("POST /: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status: want 200, got %d", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	s := string(body)
+	if !strings.Contains(s, "non-negative integer") {
+		t.Errorf("error response should describe the validation failure, got:\n%s", s)
+	}
+	// No result should have been sent.
+	select {
+	case res := <-results:
+		t.Errorf("expected no result on invalid input, got %+v", res)
+	default:
+	}
+}
+
+func TestHandler_POST_NegativeIntShowsError(t *testing.T) {
+	srv, results := newTestServer(t, config.DefaultPolicy(), filepath.Join(t.TempDir(), "p.yaml"))
+
+	form := url.Values{
+		"autoReopenOnRecurrence":         {"true"},
+		"findingFPSuppressionThreshold":  {"-1"}, // negative
+		"findingFPSuppressionExpiryDays": {"90"},
+		"ruleTuneScanThreshold":          {"5"},
+		"acceptedDefaultExpiryDays":      {"180"},
+	}
+	resp, err := http.PostForm(srv.URL+"/", form)
+	if err != nil {
+		t.Fatalf("POST /: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "non-negative integer") {
+		t.Error("negative int should surface validation error")
+	}
+	select {
+	case res := <-results:
+		t.Errorf("expected no result on invalid input, got %+v", res)
+	default:
+	}
+}
+
+func TestHandler_Cancel(t *testing.T) {
+	srv, results := newTestServer(t, config.DefaultPolicy(), filepath.Join(t.TempDir(), "p.yaml"))
+
+	resp, err := http.Get(srv.URL + "/cancel")
+	if err != nil {
+		t.Fatalf("GET /cancel: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "cancelled") {
+		t.Errorf("cancel page should say cancelled, got:\n%s", string(body))
+	}
+
+	select {
+	case res := <-results:
+		if res.Saved {
+			t.Error("cancel must not set Saved=true")
+		}
+		if res.Err != nil {
+			t.Errorf("cancel must not set Err, got %v", res.Err)
+		}
+	default:
+		t.Fatal("expected result on cancel, got none")
+	}
+}
+
+func TestHandler_DonePageContainsPath(t *testing.T) {
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "triage-policy.yaml")
+	srv, _ := newTestServer(t, config.DefaultPolicy(), outPath)
+
+	form := url.Values{
+		"autoReopenOnRecurrence":         {"true"},
+		"findingFPSuppressionThreshold":  {"3"},
+		"findingFPSuppressionExpiryDays": {"90"},
+		"ruleTuneScanThreshold":          {"5"},
+		"acceptedDefaultExpiryDays":      {"180"},
+	}
+	resp, err := http.PostForm(srv.URL+"/", form)
+	if err != nil {
+		t.Fatalf("POST /: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), outPath) {
+		t.Errorf("done page should show the written path %q", outPath)
+	}
+}


### PR DESCRIPTION
## Summary

Adds `zap-kb onboard -web [-port N]` as a browser-based alternative to the Bubble Tea TUI (slice 1c-iii). Same policy knobs, same field descriptions, same `triage-policy.yaml` output — for operators who prefer a browser over a terminal wizard.

```
$ zap-kb onboard -web
Triage policy onboarding: http://127.0.0.1:54321
```

Browser opens automatically; operator fills the form and clicks **Save policy**; server shuts down; YAML written.

## What's in the box

- `internal/webui/onboard/handler.go` — `NewHandler` (testable `http.Handler`) + `Run` (listen on `127.0.0.1`, print URL, `xdg-open`/`open`/`rundll32`, block until save/cancel). Plain HTML + CSS, no JS framework, no new Go deps (stdlib `net/http` + `html/template` only).
- `internal/webui/onboard/handler_test.go` — 7 `httptest`-based tests: GET renders form, defaults pre-filled (checkbox checked, threshold=3), POST valid saves YAML + sends Result, POST round-trips through `LoadPolicy`, POST invalid int shows inline error, POST negative int shows error, GET /cancel sends cancelled Result.
- `cmd/zap-kb/onboard_cmd.go` — adds `-web` and `-port` flags; routes to `webonboard.Run` when `-web` is set, TUI path unchanged otherwise.

Also includes the Copilot review fixes from PR #76 (already pushed to that branch):
- Remove `"n"` from `stepWelcome` bindings
- Forward non-key messages to `textinput.Update` (cursor blink fix)
- Replace hardcoded `/tmp/` paths with `t.TempDir()`
- Add `toolchain go1.24.7` to `go.mod`
- `TestWritePolicy_Overwrites` + `TestWritePolicy_RoundTrip`

## Stacked PR
Base = `claude/epic71-slice1c-iii-tui-onboarding` (PR #76). Merge #76 first, then retarget this to `main`.

## Coming next
- **Slice 2**: acceptance-expired queue (#58) + `history[]` timeline on Confluence finding pages (#62).

## Test plan
- [x] `go test ./...` — 14 packages green
- [x] `go build ./...`, `go vet ./...`
- [ ] Reviewer: `go run ./cmd/zap-kb onboard -web -path /tmp/p.yaml`, fill the form, click Save, verify YAML written
- [ ] Reviewer: click Cancel, verify no file written
- [ ] Reviewer: enter `-1` in a number field, verify inline error, verify no file written

Refs #71 #58

https://claude.ai/code/session_01NJVhm9tL9jfcDZnHk93AEx

---
_Generated by [Claude Code](https://claude.ai/code/session_01NJVhm9tL9jfcDZnHk93AEx)_