### PR TITLE
feat(occurrence): scan-observation vs finding-verdict separation (#60)

### DIFF
--- a/zap-kb/internal/entities/merge.go
+++ b/zap-kb/internal/entities/merge.go
@@ -1,7 +1,9 @@
 package entities
 
 import (
+	"fmt"
 	"log"
+	"os"
 	"sort"
 	"strings"
 	"time"
@@ -166,7 +168,59 @@ func MergeWithPolicy(base, add EntitiesFile, policy config.TriagePolicy) Entitie
 	out := mergeCore(base, add, policy)
 	applyFindingFPAutoSuppression(&out, policy)
 	applyRuleTuneScanTags(&out, policy)
+	warnOccurrenceStatusDivergence(&out)
 	return out
+}
+
+// warnOccurrenceStatusDivergence prints a [merge] warning line for each
+// occurrence whose analyst.Status diverges from its parent finding's
+// analyst.Status. Both statuses are compared after canonicalisation; the
+// warning fires only when both are non-empty and differ. Per #60, occurrence
+// status is writable but is NEVER propagated up — the warning makes the
+// divergence visible without blocking the merge. Output is sorted by
+// occurrence ID so CI logs are deterministic.
+func warnOccurrenceStatusDivergence(ef *EntitiesFile) {
+	if ef == nil {
+		return
+	}
+	findStatus := make(map[string]string, len(ef.Findings))
+	for i := range ef.Findings {
+		f := &ef.Findings[i]
+		if f.Analyst == nil {
+			continue
+		}
+		s := strings.TrimSpace(CanonicalAnalystStatus(f.Analyst.Status))
+		if s != "" {
+			findStatus[f.FindingID] = s
+		}
+	}
+	type divergence struct{ occID, occStatus, findingStatus, findingID string }
+	var divergences []divergence
+	for i := range ef.Occurrences {
+		o := &ef.Occurrences[i]
+		if o.Analyst == nil {
+			continue
+		}
+		os := strings.TrimSpace(CanonicalAnalystStatus(o.Analyst.Status))
+		if os == "" {
+			continue
+		}
+		fs := findStatus[o.FindingID]
+		if fs == "" || fs == os {
+			continue
+		}
+		divergences = append(divergences, divergence{
+			occID:         o.OccurrenceID,
+			occStatus:     os,
+			findingStatus: fs,
+			findingID:     o.FindingID,
+		})
+	}
+	sort.Slice(divergences, func(i, j int) bool { return divergences[i].occID < divergences[j].occID })
+	for _, d := range divergences {
+		fmt.Fprintf(os.Stderr, "[merge] warning: occurrence %s status=%q diverges from finding %s status=%q (occurrence status is not propagated)\n",
+			d.occID, d.occStatus, d.findingID, d.findingStatus)
+	}
 }
 
 // mergeCore is the union/merge work; it does NOT apply the post-merge policy

--- a/zap-kb/internal/entities/merge.go
+++ b/zap-kb/internal/entities/merge.go
@@ -201,17 +201,17 @@ func warnOccurrenceStatusDivergence(ef *EntitiesFile) {
 		if o.Analyst == nil {
 			continue
 		}
-		os := strings.TrimSpace(CanonicalAnalystStatus(o.Analyst.Status))
-		if os == "" {
+		occStatus := strings.TrimSpace(CanonicalAnalystStatus(o.Analyst.Status))
+		if occStatus == "" {
 			continue
 		}
 		fs := findStatus[o.FindingID]
-		if fs == "" || fs == os {
+		if fs == "" || fs == occStatus {
 			continue
 		}
 		divergences = append(divergences, divergence{
 			occID:         o.OccurrenceID,
-			occStatus:     os,
+			occStatus:     occStatus,
 			findingStatus: fs,
 			findingID:     o.FindingID,
 		})

--- a/zap-kb/internal/entities/merge_test.go
+++ b/zap-kb/internal/entities/merge_test.go
@@ -554,14 +554,22 @@ func captureStderr(t *testing.T, fn func()) string {
 	}
 	orig := os.Stderr
 	os.Stderr = w
+	defer func() { os.Stderr = orig }()
 	done := make(chan string, 1)
 	go func() {
+		defer r.Close()
 		buf, _ := io.ReadAll(r)
 		done <- string(buf)
 	}()
+	defer func() {
+		if w != nil {
+			_ = w.Close()
+			w = nil
+		}
+	}()
 	fn()
-	w.Close()
-	os.Stderr = orig
+	_ = w.Close()
+	w = nil
 	return <-done
 }
 

--- a/zap-kb/internal/entities/merge_test.go
+++ b/zap-kb/internal/entities/merge_test.go
@@ -1,6 +1,11 @@
 package entities
 
-import "testing"
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
 
 func analystPtr(status string) *Analyst {
 	return &Analyst{Status: status}
@@ -538,5 +543,91 @@ func TestMerge_FindingAnalyst_Preserved(t *testing.T) {
 		if !refs["KAN-1"] || !refs["KAN-2"] {
 			t.Errorf("TicketRefs: want [KAN-1 KAN-2], got %v", a.TicketRefs)
 		}
+	}
+}
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	orig := os.Stderr
+	os.Stderr = w
+	done := make(chan string, 1)
+	go func() {
+		buf, _ := io.ReadAll(r)
+		done <- string(buf)
+	}()
+	fn()
+	w.Close()
+	os.Stderr = orig
+	return <-done
+}
+
+// TestWarnOccurrenceStatusDivergence_EmitsLineWhenDivergent verifies the
+// merge-time warning fires when an occurrence status differs from its parent
+// finding status (#60 AC: occurrence status is writable but is not propagated
+// up; divergence is logged, not blocked).
+func TestWarnOccurrenceStatusDivergence_EmitsLineWhenDivergent(t *testing.T) {
+	ef := EntitiesFile{
+		Findings: []Finding{{
+			FindingID: "fin-1",
+			Analyst:   &Analyst{Status: "accepted"},
+		}},
+		Occurrences: []Occurrence{{
+			OccurrenceID: "occ-A",
+			FindingID:    "fin-1",
+			Analyst:      &Analyst{Status: "open"},
+		}},
+	}
+	out := captureStderr(t, func() { warnOccurrenceStatusDivergence(&ef) })
+	if !strings.Contains(out, "occ-A") {
+		t.Errorf("expected occurrence ID in warning; got: %s", out)
+	}
+	if !strings.Contains(out, "fin-1") {
+		t.Errorf("expected finding ID in warning; got: %s", out)
+	}
+	if !strings.Contains(out, `"open"`) || !strings.Contains(out, `"accepted"`) {
+		t.Errorf("expected both statuses in warning; got: %s", out)
+	}
+}
+
+// TestWarnOccurrenceStatusDivergence_SilentWhenAligned verifies no warning
+// fires when occurrence and finding statuses match, or when one side is empty.
+func TestWarnOccurrenceStatusDivergence_SilentWhenAligned(t *testing.T) {
+	cases := []struct {
+		name string
+		ef   EntitiesFile
+	}{
+		{
+			"matching statuses",
+			EntitiesFile{
+				Findings:    []Finding{{FindingID: "f1", Analyst: &Analyst{Status: "open"}}},
+				Occurrences: []Occurrence{{OccurrenceID: "o1", FindingID: "f1", Analyst: &Analyst{Status: "open"}}},
+			},
+		},
+		{
+			"empty occurrence status",
+			EntitiesFile{
+				Findings:    []Finding{{FindingID: "f1", Analyst: &Analyst{Status: "open"}}},
+				Occurrences: []Occurrence{{OccurrenceID: "o1", FindingID: "f1", Analyst: &Analyst{}}},
+			},
+		},
+		{
+			"empty finding status",
+			EntitiesFile{
+				Findings:    []Finding{{FindingID: "f1"}},
+				Occurrences: []Occurrence{{OccurrenceID: "o1", FindingID: "f1", Analyst: &Analyst{Status: "open"}}},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := captureStderr(t, func() { warnOccurrenceStatusDivergence(&tc.ef) })
+			if strings.TrimSpace(out) != "" {
+				t.Errorf("expected silent; got: %s", out)
+			}
+		})
 	}
 }

--- a/zap-kb/internal/output/confluence/analyst_log.go
+++ b/zap-kb/internal/output/confluence/analyst_log.go
@@ -41,16 +41,56 @@ func extractOccurrenceNote(body string) string {
 // buildOccurrenceNoteSection wraps the preserved analyst note in markers with
 // a heading. On first publish (existingNote == "") a placeholder prompt is
 // seeded so analysts know the block is editable.
+//
+// The heading "Scan Observation" is intentional: this block is occurrence-
+// scoped (per-scan repro/evidence), distinct from the finding-level verdict
+// rendered separately in buildFindingVerdictSection.
 func buildOccurrenceNoteSection(existingNote string) string {
 	body := strings.TrimSpace(existingNote)
 	if body == "" {
-		body = `<p><em>Add analyst notes, repro steps, or context here. This block is preserved across re-publishes.</em></p>`
+		body = `<p><em>Add scan-specific observations, repro steps, or evidence here. This block is preserved across re-publishes and is independent of the finding-level verdict above.</em></p>`
 	}
 	var b strings.Builder
-	b.WriteString(`<h2>Analyst Note</h2>`)
+	b.WriteString(`<h2>Scan Observation</h2>`)
 	b.WriteString(occNoteStart)
 	b.WriteString(body)
 	b.WriteString(occNoteEnd)
+	return b.String()
+}
+
+// buildFindingVerdictSection renders a read-only block on occurrence pages
+// showing the parent finding's analyst verdict (status, owner, notes,
+// rationale). The verdict is finding-level — analysts who need to amend it
+// edit the finding page, not the occurrence page. Returns "" when the parent
+// finding has no analyst block.
+func buildFindingVerdictSection(f *entities.Finding) string {
+	if f == nil || f.Analyst == nil {
+		return ""
+	}
+	status := strings.TrimSpace(entities.CanonicalAnalystStatus(f.Analyst.Status))
+	owner := strings.TrimSpace(f.Analyst.Owner)
+	notes := strings.TrimSpace(f.Analyst.Notes)
+	rationale := strings.TrimSpace(f.Analyst.Rationale)
+	if status == "" && owner == "" && notes == "" && rationale == "" {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString(`<h2>Finding Verdict</h2>`)
+	b.WriteString(`<p><em>Finding-level triage decision (read-only here — edit on the finding page).</em></p>`)
+	b.WriteString(`<table><tbody>`)
+	writeRow := func(key, val string) {
+		if val == "" {
+			return
+		}
+		b.WriteString(`<tr><th>` + escapeHTML(key) + `</th><td>` + val + `</td></tr>`)
+	}
+	if status != "" {
+		writeRow("Status", triageStatusMacro(status))
+	}
+	writeRow("Owner", escapeHTML(owner))
+	writeRow("Verdict notes", escapeHTML(notes))
+	writeRow("Rationale", escapeHTML(rationale))
+	b.WriteString(`</tbody></table>`)
 	return b.String()
 }
 

--- a/zap-kb/internal/output/confluence/analyst_log.go
+++ b/zap-kb/internal/output/confluence/analyst_log.go
@@ -48,7 +48,7 @@ func extractOccurrenceNote(body string) string {
 func buildOccurrenceNoteSection(existingNote string) string {
 	body := strings.TrimSpace(existingNote)
 	if body == "" {
-		body = `<p><em>Add scan-specific observations, repro steps, or evidence here. This block is preserved across re-publishes and is independent of the finding-level verdict above.</em></p>`
+		body = `<p><em>Add scan-specific observations, repro steps, or evidence here. This block is preserved across re-publishes and is separate from any finding-level verdict.</em></p>`
 	}
 	var b strings.Builder
 	b.WriteString(`<h2>Scan Observation</h2>`)

--- a/zap-kb/internal/output/confluence/analyst_log_test.go
+++ b/zap-kb/internal/output/confluence/analyst_log_test.go
@@ -467,8 +467,8 @@ func TestExtractOccurrenceNote_Absent(t *testing.T) {
 
 func TestExtractOccurrenceNote_RoundTrip(t *testing.T) {
 	section := buildOccurrenceNoteSection("<p>my analyst note</p>")
-	if !strings.Contains(section, "<h2>Analyst Note</h2>") {
-		t.Errorf("expected heading in built section, got: %s", section)
+	if !strings.Contains(section, "<h2>Scan Observation</h2>") {
+		t.Errorf("expected 'Scan Observation' heading in built section, got: %s", section)
 	}
 	if !strings.Contains(section, occNoteStart) || !strings.Contains(section, occNoteEnd) {
 		t.Errorf("expected markers in built section, got: %s", section)
@@ -483,8 +483,50 @@ func TestExtractOccurrenceNote_RoundTrip(t *testing.T) {
 
 func TestBuildOccurrenceNoteSection_SeedsPlaceholderWhenEmpty(t *testing.T) {
 	section := buildOccurrenceNoteSection("")
-	if !strings.Contains(section, "Add analyst notes") {
-		t.Errorf("expected placeholder seed, got: %s", section)
+	if !strings.Contains(section, "scan-specific observations") {
+		t.Errorf("expected scan-specific placeholder seed, got: %s", section)
+	}
+}
+
+func TestBuildFindingVerdictSection_RendersAllFields(t *testing.T) {
+	f := &entities.Finding{
+		FindingID: "fin-1",
+		Analyst: &entities.Analyst{
+			Status:    "accepted",
+			Owner:     "alice",
+			Notes:     "low risk in this env",
+			Rationale: "compensating control: WAF",
+		},
+	}
+	section := buildFindingVerdictSection(f)
+	for _, want := range []string{
+		"<h2>Finding Verdict</h2>",
+		"alice",
+		"low risk in this env",
+		"compensating control: WAF",
+		`ac:name="status"`, // status macro
+	} {
+		if !strings.Contains(section, want) {
+			t.Errorf("expected %q in verdict section; got:\n%s", want, section)
+		}
+	}
+}
+
+func TestBuildFindingVerdictSection_EmptyWhenNoAnalystData(t *testing.T) {
+	cases := []struct {
+		name string
+		f    *entities.Finding
+	}{
+		{"nil finding", nil},
+		{"nil analyst", &entities.Finding{FindingID: "x"}},
+		{"empty analyst", &entities.Finding{FindingID: "x", Analyst: &entities.Analyst{}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := buildFindingVerdictSection(tc.f); got != "" {
+				t.Errorf("expected empty section; got: %s", got)
+			}
+		})
 	}
 }
 

--- a/zap-kb/internal/output/confluence/exporter.go
+++ b/zap-kb/internal/output/confluence/exporter.go
@@ -3349,7 +3349,11 @@ func prependOccurrenceProperties(storageBody string, o *entities.Occurrence, ei 
 	infoTable.WriteString(`</tbody></table>`)
 
 	workflowSection := jiraWorkflowSection(ticketRefs, jiraBaseURL, jiraStatusByKey, jiraStatusSynced)
-	return editInstruction + infoTable.String() + workflowSection + occNoteSection + storageBody
+	verdictSection := ""
+	if ei != nil {
+		verdictSection = buildFindingVerdictSection(ei.finds[o.FindingID])
+	}
+	return editInstruction + infoTable.String() + workflowSection + verdictSection + occNoteSection + storageBody
 }
 
 // --- Confluence Labels API ---


### PR DESCRIPTION
## Summary

Closes #60. Implements the four ACs for occurrence-level scan evidence notes:

**Confluence rendering** (`analyst_log.go`, `exporter.go`):
- Renames the occurrence-level "Analyst Note" heading to **"Scan Observation"** so it's unambiguously occurrence-scoped (not finding-level). Placeholder seed updated to prompt for scan-specific repro/evidence.
- Adds **`buildFindingVerdictSection`**: a read-only block rendered on occurrence pages showing the parent finding's `status / owner / notes / rationale`, so analysts see both the scan observation and the finding-level verdict on one page without cross-page navigation.

**Merge-time consistency** (`merge.go`):
- Adds **`warnOccurrenceStatusDivergence`**: prints a `[merge] warning:` line to stderr for each occurrence whose canonical analyst.status differs from its parent finding's. Output is sorted by occurrence ID for deterministic CI logs. **Does not block the merge** — purely advisory.
- Confirmed by code inspection: `mergeCore` already only calls `mergeAnalyst` within the same level (finding↔finding, occurrence↔occurrence). Occurrence status is **never propagated up** to the finding under any code path.

**Tests:**
- Update `TestExtractOccurrenceNote_RoundTrip` / `TestBuildOccurrenceNoteSection_SeedsPlaceholderWhenEmpty` for the new heading + placeholder.
- Add `TestBuildFindingVerdictSection_RendersAllFields` + `TestBuildFindingVerdictSection_EmptyWhenNoAnalystData`.
- Add `TestWarnOccurrenceStatusDivergence_EmitsLineWhenDivergent` + `TestWarnOccurrenceStatusDivergence_SilentWhenAligned` with stderr capture.

## AC checklist

- [x] Occurrence `analyst.notes` is editable independently of finding `analyst.notes` (already true in schema; rendering now visually distinct)
- [x] Occurrence-level `analyst.status` is writable but the KB warns (not blocks) if occurrence status differs from parent finding status — log line emitted on merge
- [x] Confluence occurrence pages display occurrence notes in a visually distinct section from finding-level notes (`Scan Observation` vs `Finding Verdict`)
- [x] Merge logic does not propagate occurrence `analyst.status` up to the finding level under any circumstances

## Test plan

- [x] `go test ./internal/entities/... -run TestWarnOccurrence` — 4 cases pass
- [x] `go test ./internal/output/confluence/... -run "TestExtractOccurrenceNote|TestBuildOccurrenceNoteSection|TestBuildFindingVerdictSection"` — pass
- [x] `gofmt -l .` clean, `go vet ./...` clean, `go build ./...` clean
- [x] Full `go test ./...` passes

Closes #60

---
_Generated by [Claude Code](https://claude.ai/code/session_01NJVhm9tL9jfcDZnHk93AEx)_