### PR TITLE
feat(handoff): triage queue ownership across KB/Jira/Confluence (#61)

### DIFF
--- a/zap-kb/cmd/zap-kb/jira_sync.go
+++ b/zap-kb/cmd/zap-kb/jira_sync.go
@@ -216,6 +216,38 @@ func containsString(items []string, want string) bool {
 	return false
 }
 
+// parseJiraUserMap parses a comma-separated "owner=accountId" list into a
+// map suitable for jira.Options.UsernameMap. Entries missing the "=" or with
+// blank halves are skipped silently. Returns nil for empty input so callers
+// can pass it through without checking.
+func parseJiraUserMap(raw string) map[string]string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	out := make(map[string]string)
+	for _, pair := range strings.Split(raw, ",") {
+		pair = strings.TrimSpace(pair)
+		if pair == "" {
+			continue
+		}
+		eq := strings.IndexByte(pair, '=')
+		if eq < 1 || eq == len(pair)-1 {
+			continue
+		}
+		key := strings.TrimSpace(pair[:eq])
+		val := strings.TrimSpace(pair[eq+1:])
+		if key == "" || val == "" {
+			continue
+		}
+		out[key] = val
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
 func hasFindingTicketRefs(ent entities.EntitiesFile) bool {
 	for _, finding := range ent.Findings {
 		if finding.Analyst == nil {

--- a/zap-kb/cmd/zap-kb/jira_sync_test.go
+++ b/zap-kb/cmd/zap-kb/jira_sync_test.go
@@ -237,3 +237,35 @@ func TestContainsCustomDefinitions(t *testing.T) {
 		t.Fatal("expected custom definition detection")
 	}
 }
+
+func TestParseJiraUserMap(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want map[string]string
+	}{
+		{"empty", "", nil},
+		{"whitespace only", "   ", nil},
+		{"single pair", "alice=acc1", map[string]string{"alice": "acc1"}},
+		{
+			"multiple pairs with whitespace",
+			"alice=acc1, bob = acc2 ,carol=acc3",
+			map[string]string{"alice": "acc1", "bob": "acc2", "carol": "acc3"},
+		},
+		{"skips malformed", "alice=acc1,bad,=missing,key=,ok=v", map[string]string{"alice": "acc1", "ok": "v"}},
+		{"all malformed returns nil", ",,bad,=,", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseJiraUserMap(tc.in)
+			if len(got) != len(tc.want) {
+				t.Fatalf("size mismatch: got %v want %v", got, tc.want)
+			}
+			for k, v := range tc.want {
+				if got[k] != v {
+					t.Errorf("key %q: got %q want %q", k, got[k], v)
+				}
+			}
+		})
+	}
+}

--- a/zap-kb/cmd/zap-kb/main.go
+++ b/zap-kb/cmd/zap-kb/main.go
@@ -81,6 +81,7 @@ func main() {
 		jiraProject        string
 		jiraServerID       string
 		jiraServerName     string
+		jiraUserMap        string
 		jiraIssueType      string
 		jiraComponent      string
 		jiraLabels         string
@@ -151,6 +152,7 @@ func main() {
 	flag.StringVar(&jiraProject, "jira-project", "", "Jira project key (e.g. SEC).")
 	flag.StringVar(&jiraServerID, "jira-server-id", "", "Confluence application-link UUID for the Jira instance (e.g. 6ee9717b-54c7-35fc-8b8c-517e863e5ce4). Enables a live Jira Issues macro on the Triage Board page when combined with -jira-server-name and -jira-project.")
 	flag.StringVar(&jiraServerName, "jira-server-name", "", "Display name of the linked Jira application (as configured on the Confluence side). Required alongside -jira-server-id and -jira-project to render the Triage Board live macro.")
+	flag.StringVar(&jiraUserMap, "jira-user-map", "", "Comma-separated KB-owner→Jira-accountId map for setting Jira assignee from analyst.owner on issue create (e.g. \"alice=5e3f...,bob=602a...\"). Owners with no mapping are logged and the issue is created unassigned.")
 	flag.StringVar(&jiraIssueType, "jira-issue-type", "Bug", "Jira issue type (default: Bug).")
 	flag.StringVar(&jiraComponent, "jira-component", "", "Optional Jira component name to assign.")
 	flag.StringVar(&jiraLabels, "jira-labels", "", "Comma-separated extra labels to add to each issue.")
@@ -681,6 +683,7 @@ func main() {
 				}
 				return jiraComponent
 			}(),
+			UsernameMap: parseJiraUserMap(jiraUserMap),
 		})
 		if err != nil {
 			log.Fatalf("jira export: %v", err)

--- a/zap-kb/internal/output/confluence/exporter.go
+++ b/zap-kb/internal/output/confluence/exporter.go
@@ -300,6 +300,7 @@ func ExportVault(ctx context.Context, vaultRoot string, opts VaultOptions) (Vaul
 		storageBody = prependJiraIssuesMacro(tp.title, storageBody, opts.JiraServerID, opts.JiraServerName, opts.JiraProjectKey)
 		storageBody = appendJiraOverviewSection(tp.title, storageBody, &ei, opts.JiraBaseURL, opts.JiraStatusByKey, opts.JiraStatusSynced)
 		storageBody = appendAcceptanceExpiredSection(tp.title, storageBody, &ei)
+		storageBody = appendUnownedSection(tp.title, storageBody, &ei)
 		// The Page Properties Report macro is intentionally NOT appended here —
 		// it depends on the page-properties macro which fails in Confluence Cloud
 		// via REST API. Triage is done by editing individual occurrence pages.
@@ -2734,6 +2735,78 @@ func warnPermanentAcceptance(ei *entityIndex) {
 	for _, id := range ids {
 		fmt.Printf("[confluence] warning: finding %q is permanently accepted (no acceptedUntil set)\n", id)
 	}
+}
+
+// appendUnownedSection appends an "Unowned" table to the Triage Board page
+// listing all status=open findings whose analyst.owner is empty (#61). The
+// section makes workload distribution visible at a glance — unowned findings
+// are findings nobody is actively triaging.
+func appendUnownedSection(pageTitle, storageBody string, ei *entityIndex) string {
+	if strings.TrimSpace(pageTitle) != "Triage Board" {
+		return storageBody
+	}
+	rows := collectUnownedRows(ei)
+	if len(rows) == 0 {
+		return storageBody
+	}
+	var b strings.Builder
+	b.WriteString(`<h2>Unowned</h2>`)
+	b.WriteString(`<p><em>Open findings with no analyst owner. Assign these to a team member so they are not silently ignored.</em></p>`)
+	b.WriteString(`<table><tbody>`)
+	b.WriteString(`<tr><th>Finding</th><th>Severity</th><th>Last seen</th></tr>`)
+	for _, row := range rows {
+		b.WriteString(`<tr><td>`)
+		b.WriteString(findingPageLink(row.FindingTitle))
+		b.WriteString(`</td><td>`)
+		if row.Severity != "" {
+			b.WriteString(riskStatusMacro(row.Severity))
+		} else {
+			b.WriteString(`-`)
+		}
+		b.WriteString(`</td><td>`)
+		b.WriteString(escapeHTML(row.LastSeen))
+		b.WriteString(`</td></tr>`)
+	}
+	b.WriteString(`</tbody></table>`)
+	return storageBody + b.String()
+}
+
+type unownedRow struct {
+	FindingTitle string
+	Severity     string
+	LastSeen     string
+	FindingID    string
+}
+
+func collectUnownedRows(ei *entityIndex) []unownedRow {
+	if ei == nil {
+		return nil
+	}
+	var rows []unownedRow
+	for _, f := range ei.finds {
+		if f == nil || f.Analyst == nil {
+			continue
+		}
+		if entities.CanonicalAnalystStatus(strings.TrimSpace(f.Analyst.Status)) != "open" {
+			continue
+		}
+		if strings.TrimSpace(f.Analyst.Owner) != "" {
+			continue
+		}
+		rows = append(rows, unownedRow{
+			FindingTitle: findingPageTitle(f, ei),
+			Severity:     strings.TrimSpace(f.Risk),
+			LastSeen:     strings.TrimSpace(f.LastSeen),
+			FindingID:    f.FindingID,
+		})
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if riskRank(rows[i].Severity) != riskRank(rows[j].Severity) {
+			return riskRank(rows[i].Severity) < riskRank(rows[j].Severity)
+		}
+		return rows[i].FindingID < rows[j].FindingID
+	})
+	return rows
 }
 
 // appendAcceptanceExpiredSection appends an "Acceptance Expired" table to the

--- a/zap-kb/internal/output/confluence/exporter_test.go
+++ b/zap-kb/internal/output/confluence/exporter_test.go
@@ -2898,6 +2898,72 @@ func TestAppendAcceptanceExpiredSection_OnlyOnTriageBoard(t *testing.T) {
 	}
 }
 
+func TestAppendUnownedSection_RendersOpenUnownedFindings(t *testing.T) {
+	defs := map[string]*entities.Definition{
+		"def-1": {DefinitionID: "def-1", Alert: "SQL Injection"},
+		"def-2": {DefinitionID: "def-2", Alert: "XSS"},
+		"def-3": {DefinitionID: "def-3", Alert: "Closed One"},
+	}
+	ei := &entityIndex{
+		defs: defs,
+		finds: map[string]*entities.Finding{
+			"fin-1": {
+				FindingID: "fin-1", DefinitionID: "def-1", Risk: "High",
+				Analyst: &entities.Analyst{Status: "open", Owner: ""},
+			},
+			"fin-2": {
+				FindingID: "fin-2", DefinitionID: "def-2", Risk: "Medium",
+				Analyst: &entities.Analyst{Status: "open", Owner: "alice"},
+			},
+			"fin-3": {
+				FindingID: "fin-3", DefinitionID: "def-3", Risk: "High",
+				Analyst: &entities.Analyst{Status: "fixed", Owner: ""},
+			},
+		},
+	}
+	out := appendUnownedSection("Triage Board", "<p>body</p>", ei)
+	if !strings.Contains(out, "<h2>Unowned</h2>") {
+		t.Errorf("expected 'Unowned' heading; got: %s", out)
+	}
+	if !strings.Contains(out, "SQL Injection") {
+		t.Errorf("expected SQL Injection (open + unowned) in section; got: %s", out)
+	}
+	if strings.Contains(out, "XSS") {
+		t.Errorf("XSS has owner — must not appear; got: %s", out)
+	}
+	if strings.Contains(out, "Closed One") {
+		t.Errorf("fixed findings must not appear; got: %s", out)
+	}
+}
+
+func TestAppendUnownedSection_OnlyOnTriageBoard(t *testing.T) {
+	ei := &entityIndex{
+		defs: map[string]*entities.Definition{"def-1": {DefinitionID: "def-1", Alert: "X"}},
+		finds: map[string]*entities.Finding{
+			"fin-1": {FindingID: "fin-1", DefinitionID: "def-1", Risk: "High", Analyst: &entities.Analyst{Status: "open"}},
+		},
+	}
+	for _, title := range []string{"KB Index", "KB Dashboard", "Issues"} {
+		out := appendUnownedSection(title, "<p>body</p>", ei)
+		if strings.Contains(out, "Unowned") {
+			t.Errorf("page %q should not get Unowned section; got: %s", title, out)
+		}
+	}
+}
+
+func TestAppendUnownedSection_NoOpWhenAllOwned(t *testing.T) {
+	ei := &entityIndex{
+		defs: map[string]*entities.Definition{"def-1": {DefinitionID: "def-1", Alert: "X"}},
+		finds: map[string]*entities.Finding{
+			"fin-1": {FindingID: "fin-1", DefinitionID: "def-1", Risk: "High", Analyst: &entities.Analyst{Status: "open", Owner: "alice"}},
+		},
+	}
+	out := appendUnownedSection("Triage Board", "<p>body</p>", ei)
+	if strings.Contains(out, "Unowned") {
+		t.Errorf("expected no section when all open findings are owned; got: %s", out)
+	}
+}
+
 func captureStdout(t *testing.T, fn func()) string {
 	t.Helper()
 	r, w, err := os.Pipe()

--- a/zap-kb/internal/output/jira/exporter.go
+++ b/zap-kb/internal/output/jira/exporter.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -40,6 +41,13 @@ type Options struct {
 	EpicIssueType string
 	// EpicComponent is an optional component name applied to detection Epics.
 	EpicComponent string
+
+	// UsernameMap maps a KB analyst owner handle (e.g. "alice") to a Jira
+	// Cloud accountId. Set by CLI flag -jira-user-map. When a finding's
+	// analyst.owner has a mapping, the issue is assigned to that account on
+	// create. When the owner is set but no mapping exists, the issue is
+	// created unassigned and a stderr warning is emitted (#61).
+	UsernameMap map[string]string
 }
 
 // httpDoer abstracts HTTP request execution for throttling and testing.
@@ -552,6 +560,19 @@ func createIssue(ctx context.Context, client httpDoer, auth, base, issueType str
 		// Classic projects use customfield_10014; that variant can be added later
 		// if users hit compatibility issues.
 		fields["parent"] = map[string]string{"key": ek}
+	}
+
+	// Assignee mapping (#61): translate KB analyst.owner → Jira accountId via
+	// opts.UsernameMap. Skip silently when there's no owner. Warn (don't block)
+	// when an owner is set but absent from the map — issue is created unassigned.
+	if f.Analyst != nil {
+		if owner := strings.TrimSpace(f.Analyst.Owner); owner != "" {
+			if accountID := strings.TrimSpace(opts.UsernameMap[owner]); accountID != "" {
+				fields["assignee"] = map[string]string{"accountId": accountID}
+			} else {
+				fmt.Fprintf(os.Stderr, "[jira] warning: no Jira accountId mapping for owner %q on finding %s; issue will be unassigned\n", owner, f.FindingID)
+			}
+		}
 	}
 
 	body := map[string]any{"fields": fields}

--- a/zap-kb/internal/output/jira/exporter_test.go
+++ b/zap-kb/internal/output/jira/exporter_test.go
@@ -350,6 +350,21 @@ func TestExport_OptInTagAllowsLowSeverityFinding(t *testing.T) {
 	}
 }
 
+// decodeIssuePayloadFields unmarshals a captured create-issue request body
+// and returns the "fields" sub-object as a generic map. Test helper for
+// asserting on individual field presence/values without relying on JSON
+// substring matching.
+func decodeIssuePayloadFields(t *testing.T, raw []byte) map[string]any {
+	t.Helper()
+	var body struct {
+		Fields map[string]any `json:"fields"`
+	}
+	if err := json.Unmarshal(raw, &body); err != nil {
+		t.Fatalf("unmarshal payload: %v\nraw=%s", err, raw)
+	}
+	return body.Fields
+}
+
 // TestExport_AssigneeFromUsernameMap verifies #61 AC3: when a finding's
 // analyst.owner has a mapping in opts.UsernameMap, the create-issue payload
 // includes assignee.accountId. When no mapping exists, the payload omits
@@ -381,8 +396,13 @@ func TestExport_AssigneeFromUsernameMap(t *testing.T) {
 	if _, err := Export(context.Background(), ef, opts); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(string(capturedPayload), `"assignee":{"accountId":"5e3fabc"}`) {
-		t.Errorf("expected assignee accountId in payload; got: %s", capturedPayload)
+	fields := decodeIssuePayloadFields(t, capturedPayload)
+	assignee, ok := fields["assignee"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected fields.assignee to be an object; got: %#v", fields["assignee"])
+	}
+	if got := assignee["accountId"]; got != "5e3fabc" {
+		t.Errorf("expected assignee.accountId=%q; got %#v", "5e3fabc", got)
 	}
 }
 
@@ -410,7 +430,8 @@ func TestExport_OwnerWithoutMappingOmitsAssignee(t *testing.T) {
 	if _, err := Export(context.Background(), ef, opts); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if strings.Contains(string(capturedPayload), `"assignee"`) {
-		t.Errorf("expected NO assignee in payload (no mapping for 'carol'); got: %s", capturedPayload)
+	fields := decodeIssuePayloadFields(t, capturedPayload)
+	if _, present := fields["assignee"]; present {
+		t.Errorf("expected NO assignee in payload (no mapping for 'carol'); got: %#v", fields["assignee"])
 	}
 }

--- a/zap-kb/internal/output/jira/exporter_test.go
+++ b/zap-kb/internal/output/jira/exporter_test.go
@@ -3,6 +3,7 @@ package jira
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -346,5 +347,70 @@ func TestExport_OptInTagAllowsLowSeverityFinding(t *testing.T) {
 	}
 	if int(atomic.LoadInt64(&createCount)) != 1 {
 		t.Fatalf("expected 1 POST call, got %d", createCount)
+	}
+}
+
+// TestExport_AssigneeFromUsernameMap verifies #61 AC3: when a finding's
+// analyst.owner has a mapping in opts.UsernameMap, the create-issue payload
+// includes assignee.accountId. When no mapping exists, the payload omits
+// assignee (issue created unassigned + warning logged).
+func TestExport_AssigneeFromUsernameMap(t *testing.T) {
+	var capturedPayload []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/rest/api/3/search/jql":
+			_ = json.NewEncoder(w).Encode(searchResponse(""))
+		case r.Method == http.MethodPost && r.URL.Path == "/rest/api/3/issue":
+			capturedPayload, _ = io.ReadAll(r.Body)
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]string{"key": "SEC-1"})
+		default:
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	}))
+	defer srv.Close()
+
+	f := makeFinding("fin-mapped", "high", "https://example.com/x")
+	f.Analyst = &entities.Analyst{Owner: "alice"}
+	ef := makeEntities(f)
+
+	opts := defaultOpts(srv.URL)
+	opts.UsernameMap = map[string]string{"alice": "5e3fabc"}
+	if _, err := Export(context.Background(), ef, opts); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(string(capturedPayload), `"assignee":{"accountId":"5e3fabc"}`) {
+		t.Errorf("expected assignee accountId in payload; got: %s", capturedPayload)
+	}
+}
+
+func TestExport_OwnerWithoutMappingOmitsAssignee(t *testing.T) {
+	var capturedPayload []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/rest/api/3/search/jql":
+			_ = json.NewEncoder(w).Encode(searchResponse(""))
+		case r.Method == http.MethodPost && r.URL.Path == "/rest/api/3/issue":
+			capturedPayload, _ = io.ReadAll(r.Body)
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]string{"key": "SEC-1"})
+		}
+	}))
+	defer srv.Close()
+
+	f := makeFinding("fin-unmapped", "high", "https://example.com/x")
+	f.Analyst = &entities.Analyst{Owner: "carol"} // not in map
+	ef := makeEntities(f)
+
+	opts := defaultOpts(srv.URL)
+	opts.UsernameMap = map[string]string{"alice": "5e3fabc"}
+	if _, err := Export(context.Background(), ef, opts); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(string(capturedPayload), `"assignee"`) {
+		t.Errorf("expected NO assignee in payload (no mapping for 'carol'); got: %s", capturedPayload)
 	}
 }

--- a/zap-kb/internal/output/jira/pull.go
+++ b/zap-kb/internal/output/jira/pull.go
@@ -164,6 +164,32 @@ func PullStatus(ctx context.Context, ef entities.EntitiesFile, opts PullOptions)
 		// Capture assignee even when the status is unmapped so live Owner
 		// display still works. Empty string means the Jira issue is unassigned.
 		rawAssignees[r.ref.key] = strings.TrimSpace(r.assignee)
+
+		// Owner write-back (#61): non-destructive — fill analyst.Owner when
+		// the KB side is empty and Jira reports an assignee. This MUST run
+		// before the r.status == "" early-continue so the write-back fires
+		// even for tickets with custom/unmapped Jira workflow states.
+		if assignee := strings.TrimSpace(r.assignee); assignee != "" {
+			switch r.ref.kind {
+			case "finding":
+				f := &ef.Findings[r.ref.idx]
+				if f.Analyst == nil {
+					f.Analyst = &entities.Analyst{}
+				}
+				if strings.TrimSpace(f.Analyst.Owner) == "" {
+					f.Analyst.Owner = assignee
+				}
+			case "occurrence":
+				o := &ef.Occurrences[r.ref.idx]
+				if o.Analyst == nil {
+					o.Analyst = &entities.Analyst{}
+				}
+				if strings.TrimSpace(o.Analyst.Owner) == "" {
+					o.Analyst.Owner = assignee
+				}
+			}
+		}
+
 		if r.status == "" {
 			res.NotFound++
 			continue
@@ -181,12 +207,6 @@ func PullStatus(ctx context.Context, ef entities.EntitiesFile, opts PullOptions)
 				f.Analyst.Status = r.status
 				res.Updated++
 			}
-			// Owner write-back (#61): non-destructive — only fill when KB
-			// owner is empty so analyst overrides on the KB side are not
-			// clobbered by Jira assignee changes.
-			if strings.TrimSpace(f.Analyst.Owner) == "" && strings.TrimSpace(r.assignee) != "" {
-				f.Analyst.Owner = strings.TrimSpace(r.assignee)
-			}
 		case "occurrence":
 			o := &ef.Occurrences[r.ref.idx]
 			if o.Analyst == nil {
@@ -197,9 +217,6 @@ func PullStatus(ctx context.Context, ef entities.EntitiesFile, opts PullOptions)
 			} else {
 				o.Analyst.Status = r.status
 				res.Updated++
-			}
-			if strings.TrimSpace(o.Analyst.Owner) == "" && strings.TrimSpace(r.assignee) != "" {
-				o.Analyst.Owner = strings.TrimSpace(r.assignee)
 			}
 		}
 	}

--- a/zap-kb/internal/output/jira/pull.go
+++ b/zap-kb/internal/output/jira/pull.go
@@ -181,6 +181,12 @@ func PullStatus(ctx context.Context, ef entities.EntitiesFile, opts PullOptions)
 				f.Analyst.Status = r.status
 				res.Updated++
 			}
+			// Owner write-back (#61): non-destructive — only fill when KB
+			// owner is empty so analyst overrides on the KB side are not
+			// clobbered by Jira assignee changes.
+			if strings.TrimSpace(f.Analyst.Owner) == "" && strings.TrimSpace(r.assignee) != "" {
+				f.Analyst.Owner = strings.TrimSpace(r.assignee)
+			}
 		case "occurrence":
 			o := &ef.Occurrences[r.ref.idx]
 			if o.Analyst == nil {
@@ -191,6 +197,9 @@ func PullStatus(ctx context.Context, ef entities.EntitiesFile, opts PullOptions)
 			} else {
 				o.Analyst.Status = r.status
 				res.Updated++
+			}
+			if strings.TrimSpace(o.Analyst.Owner) == "" && strings.TrimSpace(r.assignee) != "" {
+				o.Analyst.Owner = strings.TrimSpace(r.assignee)
 			}
 		}
 	}

--- a/zap-kb/internal/output/jira/pull_test.go
+++ b/zap-kb/internal/output/jira/pull_test.go
@@ -252,6 +252,75 @@ func TestPullStatus_MissingFieldsError(t *testing.T) {
 	}
 }
 
+func TestPullStatus_OwnerWriteBackFillsEmptyOwner(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Issue body with both status and assignee
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"fields": map[string]any{
+				"status":   map[string]string{"name": "In Progress"},
+				"assignee": map[string]string{"displayName": "Alice Example"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	ef := makeEntities(entities.Finding{
+		FindingID: "fin-empty-owner",
+		Name:      "Empty Owner",
+		Analyst: &entities.Analyst{
+			Status:     "open",
+			Owner:      "", // empty — should be filled
+			TicketRefs: []string{"KAN-7"},
+		},
+	})
+	res, err := PullStatus(context.Background(), ef, PullOptions{
+		BaseURL:  srv.URL,
+		Username: "user",
+		Token:    "token",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := res.Updated.Findings[0].Analyst.Owner; got != "Alice Example" {
+		t.Errorf("expected owner='Alice Example'; got %q", got)
+	}
+}
+
+func TestPullStatus_OwnerWriteBackPreservesExistingOwner(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"fields": map[string]any{
+				"status":   map[string]string{"name": "In Progress"},
+				"assignee": map[string]string{"displayName": "Alice Example"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	ef := makeEntities(entities.Finding{
+		FindingID: "fin-existing-owner",
+		Name:      "Existing Owner",
+		Analyst: &entities.Analyst{
+			Status:     "open",
+			Owner:      "bob", // pre-set; must NOT be overwritten
+			TicketRefs: []string{"KAN-8"},
+		},
+	})
+	res, err := PullStatus(context.Background(), ef, PullOptions{
+		BaseURL:  srv.URL,
+		Username: "user",
+		Token:    "token",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := res.Updated.Findings[0].Analyst.Owner; got != "bob" {
+		t.Errorf("expected owner unchanged='bob'; got %q", got)
+	}
+}
+
 func TestPullStatus_RawStatusesPopulated(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {

--- a/zap-kb/internal/output/jira/pull_test.go
+++ b/zap-kb/internal/output/jira/pull_test.go
@@ -287,6 +287,42 @@ func TestPullStatus_OwnerWriteBackFillsEmptyOwner(t *testing.T) {
 	}
 }
 
+func TestPullStatus_OwnerWriteBackFillsEmptyOwnerWithUnmappedStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Unmapped status — write-back must still fire because AC4 only
+		// depends on assignee presence, not status mapping.
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"fields": map[string]any{
+				"status":   map[string]string{"name": "Custom Workflow State"},
+				"assignee": map[string]string{"displayName": "Alice Example"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	ef := makeEntities(entities.Finding{
+		FindingID: "fin-empty-owner-unmapped",
+		Name:      "Empty Owner Unmapped Status",
+		Analyst: &entities.Analyst{
+			Status:     "open",
+			Owner:      "",
+			TicketRefs: []string{"KAN-9"},
+		},
+	})
+	res, err := PullStatus(context.Background(), ef, PullOptions{
+		BaseURL:  srv.URL,
+		Username: "user",
+		Token:    "token",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := res.Updated.Findings[0].Analyst.Owner; got != "Alice Example" {
+		t.Errorf("expected owner='Alice Example' for unmapped status; got %q", got)
+	}
+}
+
 func TestPullStatus_OwnerWriteBackPreservesExistingOwner(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
## Summary

Closes #61. All four ACs implemented across Confluence rendering, Jira export, and Jira pull.

### AC1 — Owner displayed prominently
Owner is already rendered on finding pages via `prependFindingProperties`, prefering live Jira assignee when available. No additional change needed.

### AC2 — Confluence "Unowned" filter
- `appendUnownedSection`: new section appended to the Triage Board page only, listing all `status=open` findings whose `analyst.owner` is empty
- Sorted by severity then finding ID for deterministic output
- No-op when no qualifying findings exist or when called for any other page

### AC3 — Jira export sets assignee from `analyst.owner`
- `Options.UsernameMap map[string]string` — KB owner handle → Jira `accountId`
- `createIssue` adds `fields["assignee"] = {accountId: <mapped>}` when owner+mapping are present
- When owner is set but no mapping exists, logs stderr warning and creates issue **unassigned** (does not block the merge or export)
- New CLI flag: `-jira-user-map "alice=accountId1,bob=accountId2"`
- `parseJiraUserMap` helper handles malformed pairs, whitespace, and returns nil for all-malformed input

### AC4 — `pull` writes Jira assignee back into `analyst.owner`
- `PullStatus` already captured `RawAssignees`; now also writes back to `analyst.Owner` when the KB owner is empty
- **Non-destructive**: existing KB-side owner values are preserved
- Applies to both findings and occurrences

## Test plan

- [x] `go test ./internal/output/confluence/... -run TestAppendUnowned` — 3 cases pass
- [x] `go test ./internal/output/jira/... -run "TestExport_Assignee|TestExport_OwnerWithout|TestPullStatus_OwnerWriteBack"` — 4 cases pass
- [x] `go test ./cmd/zap-kb/... -run TestParseJiraUserMap` — 6 cases pass
- [x] `gofmt -l .` clean, `go vet ./...` clean, `go build ./...` clean
- [x] Full `go test ./...` passes

Closes #61

---
_Generated by [Claude Code](https://claude.ai/code/session_01NJVhm9tL9jfcDZnHk93AEx)_