### PR TITLE
[codex] Enrich ZAP KB taxonomy and reporting

### DIFF
--- a/.github/workflows/zap-kb-release.yml
+++ b/.github/workflows/zap-kb-release.yml
@@ -1,0 +1,68 @@
+name: release-zap-kb
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    defaults:
+      run:
+        working-directory: zap-kb
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: zap-kb/go.mod
+
+      - name: Test
+        run: go test ./...
+
+      - name: Build release binaries
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          version="${GITHUB_REF_NAME:-manual}"
+          targets=(
+            "linux amd64"
+            "linux arm64"
+            "darwin amd64"
+            "darwin arm64"
+            "windows amd64"
+          )
+          for target in "${targets[@]}"; do
+            read -r goos goarch <<< "$target"
+            name="zap-kb-${version}-${goos}-${goarch}"
+            if [ "$goos" = "windows" ]; then
+              GOOS="$goos" GOARCH="$goarch" go build -trimpath -ldflags="-s -w" -o "dist/${name}.exe" ./cmd/zap-kb
+              (cd dist && zip "${name}.zip" "${name}.exe")
+              rm "dist/${name}.exe"
+            else
+              GOOS="$goos" GOARCH="$goarch" go build -trimpath -ldflags="-s -w" -o "dist/${name}" ./cmd/zap-kb
+              tar -C dist -czf "dist/${name}.tar.gz" "$name"
+              rm "dist/${name}"
+            fi
+          done
+          (cd dist && sha256sum * > SHA256SUMS)
+
+      - name: Upload workflow artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: zap-kb-release-${{ github.run_id }}
+          path: zap-kb/dist/*
+          if-no-files-found: error
+
+      - name: Publish GitHub release
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "$GITHUB_REF_NAME" dist/* --generate-notes --title "$GITHUB_REF_NAME"

--- a/.github/workflows/zap-kb-smoke.yml
+++ b/.github/workflows/zap-kb-smoke.yml
@@ -1,0 +1,84 @@
+name: zap-kb-smoke
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_live_zap:
+        description: "Also run a live ZAP API smoke test using ZAP_URL/ZAP_API_KEY secrets"
+        required: false
+        default: "false"
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: zap-kb
+    env:
+      ZAP_URL: ${{ secrets.ZAP_URL }}
+      ZAP_API_KEY: ${{ secrets.ZAP_API_KEY }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: zap-kb/go.mod
+
+      - name: Unit tests
+        run: go test ./...
+
+      - name: Offline pipeline smoke
+        run: |
+          set -euo pipefail
+          rm -rf out/smoke
+          mkdir -p out/smoke
+          go run ./cmd/zap-kb \
+            -in testdata/alerts_smoke.json \
+            -format entities \
+            -out out/smoke/entities.json \
+            -scan-label smoke-offline \
+            -generated-at 2026-01-01T00:00:00Z \
+            -include-detection \
+            -detection-details links \
+            -run-out out/smoke/run.json \
+            -zip-out out/smoke/run.zip
+          go run ./cmd/zap-kb \
+            -run-in out/smoke/run.json \
+            -format obsidian \
+            -obsidian-dir out/smoke/vault \
+            -report-out reports/smoke.md \
+            -report-since 2026-01-01 \
+            -report-until 2026-01-02 \
+            -report-scan smoke-offline
+          test -s out/smoke/entities.json
+          test -s out/smoke/run.json
+          test -s out/smoke/run.zip
+          test -s out/smoke/vault/INDEX.md
+          test -s out/smoke/vault/reports/smoke.md
+          grep -q "Occurrences: 2" out/smoke/vault/reports/smoke.md
+
+      - name: Live ZAP API smoke
+        if: github.event.inputs.run_live_zap == 'true'
+        run: |
+          set -euo pipefail
+          if [ -z "${ZAP_URL}" ]; then
+            echo "ZAP_URL secret is required when run_live_zap=true" >&2
+            exit 1
+          fi
+          go run ./cmd/zap-kb \
+            -format entities \
+            -out out/smoke/live-zap-entities.json \
+            -zap-url "$ZAP_URL" \
+            -api-key "$ZAP_API_KEY" \
+            -count 10 \
+            -scan-label smoke-live-zap \
+            -generated-at 2026-01-01T00:00:00Z
+
+      - name: Upload smoke artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: zap-kb-smoke-${{ github.run_id }}
+          path: zap-kb/out/smoke
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -11,9 +11,19 @@ Thumbs.db
 # Claude Code settings (may contain API keys)
 .claude/
 
+# Codex local workspace state
+.codex/
+
+# Local linked worktrees / external project mounts
+_ext_*/
+
 # Local archives of old folders
 archive/
 
 # Generated/example content
 examples/
 out/
+zap-kb/tmp/
+
+# Local walkthrough exports
+devsecops kb walkthrough.pdf

--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@ Doc map:
 ## Getting Started (zap-kb)
 See `zap-kb/README.md` for usage, flags, and examples. A GitHub Actions workflow is provided to build/vet the module on pushes and PRs.
 
+## Automation
+- `.github/workflows/zap-kb.yml`: build, format, vet, unit tests, tagged e2e test, and package build on push/PR.
+- `.github/workflows/zap-kb-run.yml`: manual ZAP-to-KB artifact generation using repository secrets.
+- `.github/workflows/zap-kb-smoke.yml`: manual offline pipeline smoke test, with optional live ZAP API smoke when `ZAP_URL` is available.
+- `.github/workflows/zap-kb-release.yml`: tagged/manual release build for Linux, macOS, and Windows binaries with checksums.
+
+## Current Scope
+`zap-kb` is the active source module. Additional adapters for tools such as Burp, SAST, SBOM, dependency scanners, or cloud findings are intentionally deferred until a shared importer contract is designed.
+
 ## Contributing
 - Keep modules self-contained under their own directory.
 - Prefer normalized exchange formats (entities) and deterministic outputs to support versioning and diffs.

--- a/zap-kb/.gitignore
+++ b/zap-kb/.gitignore
@@ -38,3 +38,4 @@ docs/data/*.json
 # Artifacts
 dist/
 coverage.out
+tmp/

--- a/zap-kb/README.md
+++ b/zap-kb/README.md
@@ -5,7 +5,7 @@ zap-kb is the ZAP-focused module of the broader DevSecOps KB project. It fetches
 The module can:
 - Fetch alerts from a running ZAP instance or read from a file.
 - Normalize data into a stable entities schema for analysis and versioning.
-- Enrich definitions with detection references from ZAP docs/GitHub.
+- Enrich definitions with MITRE taxonomy references, estimated CVSS, and optional detection references from ZAP docs/GitHub.
 - Publish an Obsidian vault with findings, occurrences, and definitions.
 
 ## Quick Start
@@ -30,6 +30,8 @@ Key flags:
 - `-plugins`: Comma/space list of plugin IDs to seed/update definitions.
 - `-all-plugins`: Discover all plugin IDs and seed/update definitions.
 - `-include-detection`: Enrich definitions with detection links.
+- `-include-mitre`: Enrich taxonomy with curated MITRE CWE/CAPEC/ATT&CK metadata (default `true`).
+- `-include-cvss`: Estimate definition CVSS from scanner risk when official CVSS is unavailable (default `true`).
 - `-detection-details`: `links|summary` (adds brief detection summary when `summary`).
 - `-include-traffic`: Attach first/all HTTP request/response snippets.
 - `-traffic-scope`: `first|all` and `-traffic-max-bytes` to limit snippet size.
@@ -80,6 +82,8 @@ Examples:
 - Finding/definition page property order: finding pages lead with Severity → Confidence → Definition (linked) → CWE → OWASP Top 10 → URL → Method → Occurrences; supplementary fields (WASC, Domain, Last/First Seen, Owner, Analyst Cases, Jira Status, Tags, Source Tool, Scans) follow. Definition pages add an `Open Findings` row and render the Detection row as a human-readable phrase ("Passive scan" rather than "passive"). Finding ID is intentionally not rendered.
 - Auth Context on occurrences: Confluence occurrence pages now render an `Auth Context` property (Authenticated/Unauthenticated) derived from captured request headers (Cookie, Authorization Bearer/Basic/Token, X-Csrf/Xsrf/Auth, X-Api-Key). Empty when no headers were captured — never guessed.
 - FP guidance on high-volume rules: CDM (10098), CSP (10038), and CDJSF (10017) each carry 4 documented benign scenarios plus an explicit "true positive when…" clause, auto-populated onto Definition pages via `zapmeta.LookupFalsePositiveGuidance` during enrichment.
+- MITRE taxonomy and CVSS enrichment are default-on and offline. CWE IDs are expanded to MITRE CWE titles/URLs, CAPEC/ATT&CK IDs are expanded when present, and source attribution is written to the entity. CVSS is marked `devsecopskb-estimated` and derived from the highest scanner risk observed for the definition; existing CVSS values are preserved.
+- Enrichment strategy details live in `docs/enrichment-strategy.md`.
 
 ## Scripts
 PowerShell helper `scripts/kb.ps1` wraps common flows:
@@ -186,6 +190,14 @@ Notes:
 GitHub Actions workflow `zap-kb-run.yml` is included for manual runs with secrets:
 - Set repo secrets: `ZAP_URL`, `ZAP_API_KEY`.
 - Run the workflow from the Actions tab; it uploads the Obsidian vault and `entities.json` as artifacts.
+
+Additional automation:
+- `zap-kb-smoke.yml` runs a reproducible offline pipeline smoke test from
+  `testdata/alerts_smoke.json`; it can optionally hit a live ZAP API when
+  `run_live_zap=true` and `ZAP_URL` is configured.
+- `zap-kb-release.yml` builds release archives for Linux, macOS, and Windows.
+  Push a `v*` tag to publish a GitHub release; run it manually to produce
+  workflow artifacts without publishing a release.
 
 ## License
 - Code: Apache-2.0 (see repository root `LICENSE`).

--- a/zap-kb/cmd/zap-kb/dispatch.go
+++ b/zap-kb/cmd/zap-kb/dispatch.go
@@ -1,0 +1,23 @@
+package main
+
+type subcommandHandler func([]string)
+
+var subcommands = map[string]subcommandHandler{
+	"config":  runConfigCommand,
+	"expired": runExpiredCommand,
+	"merge":   runMergeCommand,
+	"onboard": runOnboardCommand,
+	"pull":    runPullCommand,
+	"report":  runReportCommand,
+}
+
+func lookupSubcommand(args []string) (subcommandHandler, []string, bool) {
+	if len(args) == 0 {
+		return nil, nil, false
+	}
+	handler, ok := subcommands[args[0]]
+	if !ok {
+		return nil, nil, false
+	}
+	return handler, args[1:], true
+}

--- a/zap-kb/cmd/zap-kb/dispatch_test.go
+++ b/zap-kb/cmd/zap-kb/dispatch_test.go
@@ -1,0 +1,42 @@
+package main
+
+import "testing"
+
+func TestLookupSubcommand(t *testing.T) {
+	handler, args, ok := lookupSubcommand([]string{"merge", "-inputs", "a.json,b.json"})
+	if !ok {
+		t.Fatal("expected merge to resolve as a subcommand")
+	}
+	if handler == nil {
+		t.Fatal("expected non-nil handler")
+	}
+	if len(args) != 2 || args[0] != "-inputs" || args[1] != "a.json,b.json" {
+		t.Fatalf("unexpected remaining args: %#v", args)
+	}
+}
+
+func TestLookupSubcommandUnknown(t *testing.T) {
+	handler, args, ok := lookupSubcommand([]string{"unknown", "-flag"})
+	if ok {
+		t.Fatal("expected unknown command to fall through to global flags")
+	}
+	if handler != nil {
+		t.Fatal("expected nil handler")
+	}
+	if args != nil {
+		t.Fatalf("expected nil args, got %#v", args)
+	}
+}
+
+func TestLookupSubcommandNoArgs(t *testing.T) {
+	handler, args, ok := lookupSubcommand(nil)
+	if ok {
+		t.Fatal("expected no args to fall through")
+	}
+	if handler != nil {
+		t.Fatal("expected nil handler")
+	}
+	if args != nil {
+		t.Fatalf("expected nil args, got %#v", args)
+	}
+}

--- a/zap-kb/cmd/zap-kb/main.go
+++ b/zap-kb/cmd/zap-kb/main.go
@@ -49,6 +49,8 @@ func main() {
 		zapBase            string
 		trafficMinRisk     string
 		includeDetect      bool
+		includeMITRE       bool
+		includeCVSS        bool
 		detectDetails      string
 		initMode           bool
 		runOut             string
@@ -119,6 +121,8 @@ func main() {
 	flag.StringVar(&siteLabel, "site-label", "", "Optional site/domain label override when domains are redacted")
 	flag.StringVar(&zapBase, "zap-base-url", "", "Optional ZAP base URL to link back to messages in Obsidian")
 	flag.BoolVar(&includeDetect, "include-detection", false, "Enrich with detection logic links from ZAP docs/GitHub")
+	flag.BoolVar(&includeMITRE, "include-mitre", true, "Enrich taxonomy with curated MITRE CWE/CAPEC/ATT&CK metadata")
+	flag.BoolVar(&includeCVSS, "include-cvss", true, "Estimate definition CVSS from scanner risk when official CVSS is unavailable")
 	flag.StringVar(&detectDetails, "detection-details", "links", "Detection enrichment detail: links|summary")
 	flag.BoolVar(&initMode, "init", false, "Init KB without run data: seed/update definitions only (no alert fetch)")
 	flag.StringVar(&runOut, "run-out", "", "Write a pipeline-friendly run artifact JSON (entities+meta[+alerts])")
@@ -165,30 +169,9 @@ func main() {
 	flag.StringVar(&jiraEpicComponent, "jira-epic-component", "", "Optional Jira component name applied to detection Epics.")
 	flag.BoolVar(&allowAgentPublish, "allow-agent-publish", false, "Allow Confluence/Jira publish from sourceTool values like zap-agent (disabled by default)")
 	flag.BoolVar(&allowCustomPublish, "allow-custom-publish", false, "Allow Confluence/Jira publish when the input contains custom definitions (disabled by default)")
-	// Sub-command dispatch: if the first argument is "merge", run the merge
-	// sub-command with its own flag set and exit without touching the global flags.
-	if len(os.Args) > 1 && os.Args[1] == "merge" {
-		runMergeCommand(os.Args[2:])
-		return
-	}
-	if len(os.Args) > 1 && os.Args[1] == "report" {
-		runReportCommand(os.Args[2:])
-		return
-	}
-	if len(os.Args) > 1 && os.Args[1] == "pull" {
-		runPullCommand(os.Args[2:])
-		return
-	}
-	if len(os.Args) > 1 && os.Args[1] == "config" {
-		runConfigCommand(os.Args[2:])
-		return
-	}
-	if len(os.Args) > 1 && os.Args[1] == "onboard" {
-		runOnboardCommand(os.Args[2:])
-		return
-	}
-	if len(os.Args) > 1 && os.Args[1] == "expired" {
-		runExpiredCommand(os.Args[2:])
+	// Subcommands own their flag sets, so dispatch before parsing global flags.
+	if handler, args, ok := lookupSubcommand(os.Args[1:]); ok {
+		handler(args)
 		return
 	}
 
@@ -560,6 +543,12 @@ func main() {
 
 		// Enrich taxonomy (CWE→OWASP) from static map — always runs, best-effort
 		entities.EnrichTaxonomy(ent.Definitions)
+		if includeMITRE {
+			entities.EnrichMITRE(ent.Definitions)
+		}
+		if includeCVSS {
+			entities.EnrichCVSS(&ent)
+		}
 
 		// Optional redaction pass
 		if strings.TrimSpace(redactOpts) != "" {

--- a/zap-kb/docs/architecture.md
+++ b/zap-kb/docs/architecture.md
@@ -1,38 +1,103 @@
+# zap-kb Architecture
+
+`zap-kb` is the ZAP-focused module of DevSecOps KB. The stable boundary is
+the entities model: ZAP alerts are normalized into definitions, findings, and
+occurrences, then downstream publishers render that model into analyst-facing
+systems.
+
 ```mermaid
 flowchart LR
-subgraph ZAP
-  A[Scans] --> API[(API)]
-end
+  subgraph Sources
+    ZAPI["ZAP API"]
+    ZFILE["ZAP alert JSON"]
+    RUNIN["run.json / entities.json"]
+  end
 
-subgraph Collector
-  C1[Fetch Alerts] --> C2[De-dup] --> C3[Write JSON]
-end
+  subgraph Ingest
+    FETCH["Fetch or read alerts"]
+    DEDUP["Deduplicate within scan"]
+    NORMALIZE["Normalize to entities"]
+    MERGE["Merge with existing entities"]
+  end
 
-subgraph Stores
-  JSN[(alerts.json)]
-  ENT[(entities.json)]
-  RUN[(run.json)]
-end
+  subgraph Overlays
+    ID["Identity: stable IDs, scan.label"]
+    TIME["Temporal: observedAt, firstSeen, lastSeen"]
+    ENRICH["Enrichment: taxonomy, MITRE refs, CVSS estimates, detection links, FP guidance"]
+    POLICY["Policy: triage-policy.yaml"]
+    ANALYST["Analyst workflow: status, owner, notes, suppression, acceptance"]
+  end
 
-subgraph Overlays
-  O1["Identity overlay (scan.label in IDs)"]
-  O2["Enrichment overlay (taxonomy: CWE/CAPEC/ATT&CK/NIST/OWASP; detection; remediation)"]
-  O3["Temporal overlay (observedAt, firstSeen/lastSeen)"]
-  O4["Triage overlay (analyst.*, status)"]
-end
+  subgraph Stores
+    ALERTS["alerts.json"]
+    ENTITIES["entities.json"]
+    RUNOUT["run.json / zip artifact"]
+  end
 
-subgraph Sinks
-  OBS["Obsidian vault (INDEX, DASHBOARD, triage-board, by-domain, findings, occurrences, definitions)"]
-  REP["Reports (markdown)"]
-  DASH["Dashboards/embeds"]
-  CONF["Confluence (planned)"]
-end
+  subgraph Publishers
+    OBS["Obsidian vault"]
+    REPORT["Markdown reports"]
+    CONF["Confluence export and pull"]
+    JIRA["Jira export and status pull"]
+  end
 
-API --> C1 --> C2 --> C3 --> JSN
-JSN --> ENT
-ENT --> O1 --> O2 --> O3 --> O4 --> OBS
-ENT --> RUN
-RUN --> OBS
-ENT --> REP
-ENT --> DASH
-ENT --> CONF
+  subgraph OperatorUX
+    TUI["Terminal onboarding"]
+    WEB["Browser onboarding"]
+    CONFIG["config show/init"]
+  end
+
+  ZAPI --> FETCH
+  ZFILE --> FETCH
+  RUNIN --> MERGE
+  FETCH --> DEDUP --> ALERTS --> NORMALIZE --> MERGE
+  MERGE --> ID --> TIME --> ENRICH --> POLICY --> ANALYST --> ENTITIES
+  ENTITIES --> RUNOUT
+  ENTITIES --> OBS
+  ENTITIES --> REPORT
+  ENTITIES --> CONF
+  ENTITIES --> JIRA
+  CONF --> ANALYST
+  JIRA --> ANALYST
+  CONFIG --> POLICY
+  TUI --> POLICY
+  WEB --> POLICY
+```
+
+## Current Capabilities
+
+- Ingest from a live ZAP API, a flat ZAP alert file, a run artifact, or a bare
+  entities file.
+- Normalize ZAP data into the entities schema for deterministic diffs and
+  portable artifacts.
+- Preserve scan identity with `scan.label` so repeated alerts across scans
+  remain distinct observations.
+- Enrich definitions and findings with ZAP metadata, taxonomy fields, MITRE
+  source references, estimated CVSS, detection references, false-positive
+  guidance, and remediation text.
+- Capture bounded request/response evidence when requested, with redaction
+  controls for shared artifacts.
+- Publish an Obsidian vault with indexes, dashboards, issue pages, occurrence
+  pages, definition pages, scan views, and tuning candidates.
+- Export/pull Confluence pages while preserving analyst-owned blocks.
+- Export Jira issues and optional detection Epics, then reflect live Jira status
+  and owner back into KB output.
+- Generate Markdown reports and zipped run artifacts for CI handoff.
+- Configure triage automation with `triage-policy.yaml`, plus terminal and web
+  onboarding flows.
+
+## Explicit Non-Goals For This Slice
+
+Additional source adapters such as Burp, SAST, SBOM, dependency scanners, or
+cloud findings should be added beside `zap-kb` or behind a shared importer
+contract later. This module still treats ZAP as its first-class source.
+
+## Remaining Architecture Work
+
+- Extract a shared importer contract before adding non-ZAP adapters.
+- Keep CLI subcommands small and independently testable as the command surface
+  grows.
+- Add live-service smoke workflows for deployments that can provide ZAP, Jira,
+  and Confluence test credentials.
+- Promote the generated Obsidian/Confluence/Jira views into a dedicated analyst
+  web dashboard if the team wants an app-native workflow surface.

--- a/zap-kb/docs/enrichment-strategy.md
+++ b/zap-kb/docs/enrichment-strategy.md
@@ -1,0 +1,50 @@
+# Enrichment Strategy
+
+The KB enrichment path is deterministic by default. It should improve triage
+context without making normal CI runs depend on live third-party catalog
+downloads.
+
+## Default Enrichment
+
+Default-on enrichments run after normalization and merge:
+
+- `EnrichTaxonomy`: fills missing CWE from known ZAP metadata, then derives
+  OWASP Top 10 and CAPEC IDs from curated local maps.
+- `EnrichMITRE`: expands existing CWE, CAPEC, and ATT&CK IDs with curated
+  MITRE titles, canonical URLs, source attribution, and mapping confidence.
+- `EnrichCVSS`: estimates definition-level CVSS from the highest observed
+  scanner risk when no CVSS is already present.
+
+These can be disabled with `-include-mitre=false` or `-include-cvss=false`.
+
+## CVSS Policy
+
+Scanner alerts usually describe weakness classes, not CVEs. The KB therefore
+does not present estimated CVSS as authoritative. Estimated scores must include:
+
+- `source=devsecopskb-estimated`
+- a rationale explaining that the score was derived from scanner risk
+- the CVSS vector and version used for repeatability
+
+Existing CVSS values are never overwritten. If an official advisory or analyst
+score exists, it remains the source of truth.
+
+## MITRE Policy
+
+MITRE enrichment is a local, curated expansion of identifiers that are already
+present or derived from existing CWE mappings. It does not infer broad ATT&CK
+techniques from CWE alone. ATT&CK techniques are expanded only when a technique
+ID is already present in taxonomy, such as project-owned custom detection
+mappings.
+
+Stored taxonomy keeps both compatibility and rich fields:
+
+- compatibility fields: `cweid`, `cweUri`, `capecIds`, `attack`
+- rich fields: `cweName`, `capec`, `attackTechniques`,
+  `mappingConfidence`, `sources`
+
+## Adapter Boundary
+
+Live adapters for NVD, EPSS, OSV, MITRE catalog downloads, or vendor advisories
+should feed the same entity fields. They should not replace the offline path;
+CI and local smoke tests must continue to work without network access.

--- a/zap-kb/docs/schema/entities-v1.md
+++ b/zap-kb/docs/schema/entities-v1.md
@@ -29,7 +29,8 @@ Definition
 - pluginId
 - origin: `tool|custom`
 - alert, name, wascid
-- taxonomy: { cweid, cweUri, capecIds[], attack[], owaspTop10[], nist80053[], tags[] }
+- taxonomy: { cweid, cweName, cweUri, capecIds[], capec[], attack[], attackTechniques[], owaspTop10[], nist80053[], tags[], mappingConfidence, sources[] }
+- cvss (optional): { version, vector, baseScore, baseSeverity, source, rationale }
 - remediation: { summary, references[], guidance[], exampleFixes[], falsePositiveConditions[] }
 - detection (optional): { logicType, pluginRef, ruleSource, docsUrl, sourceUrl, matchReason, summary, signals[], defaults{threshold,strength} }
 - epicRef (optional): Jira Epic key grouping all findings for this detection; set by Jira export when `-jira-detection-epic` is enabled.
@@ -82,7 +83,14 @@ Large payloads
 - By default, store only hashes and sizes for bodies; snippets are opt-in with future flags and redaction.
 
 Enrichment
-- A future enrichment step populates taxonomy mappings and expands remediation guidance.
+- Taxonomy enrichment is default-on and deterministic. It fills missing CWE from
+  known ZAP metadata, derives OWASP/CAPEC where known, and expands existing
+  CWE/CAPEC/ATT&CK IDs with curated MITRE titles, canonical URLs, source
+  attribution, and mapping confidence.
+- CVSS enrichment is default-on and estimated when no CVSS already exists. The
+  estimate uses the highest observed scanner risk for the definition, records
+  `source=devsecopskb-estimated`, and keeps a rationale because scanner alerts
+  are weakness-based rather than CVE-based.
 - Optional detection enrichment can link a rule to its implementation and docs:
   - logicType: passive|active|unknown (inferred from rule path)
   - ruleSource: repo-like path in zap-extensions or `custom` for project-owned detection logic

--- a/zap-kb/internal/entities/entities.go
+++ b/zap-kb/internal/entities/entities.go
@@ -145,13 +145,30 @@ type RecurrenceInfo struct {
 }
 
 type Taxonomy struct {
-	CWEID      int      `json:"cweid,omitempty"`
-	CWEURI     string   `json:"cweUri,omitempty"`
-	CAPECIDs   []int    `json:"capecIds,omitempty"`
-	ATTACK     []string `json:"attack,omitempty"`
-	OWASPTop10 []string `json:"owaspTop10,omitempty"`
-	NIST80053  []string `json:"nist80053,omitempty"`
-	Tags       []string `json:"tags,omitempty"`
+	CWEID             int              `json:"cweid,omitempty"`
+	CWEName           string           `json:"cweName,omitempty"`
+	CWEURI            string           `json:"cweUri,omitempty"`
+	CAPECIDs          []int            `json:"capecIds,omitempty"`
+	CAPEC             []TaxonomyRef    `json:"capec,omitempty"`
+	ATTACK            []string         `json:"attack,omitempty"`
+	ATTACKTechniques  []TaxonomyRef    `json:"attackTechniques,omitempty"`
+	OWASPTop10        []string         `json:"owaspTop10,omitempty"`
+	NIST80053         []string         `json:"nist80053,omitempty"`
+	Tags              []string         `json:"tags,omitempty"`
+	MappingConfidence string           `json:"mappingConfidence,omitempty"`
+	Sources           []TaxonomySource `json:"sources,omitempty"`
+}
+
+type TaxonomyRef struct {
+	ID   string `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
+	URL  string `json:"url,omitempty"`
+}
+
+type TaxonomySource struct {
+	Name    string `json:"name,omitempty"`
+	URL     string `json:"url,omitempty"`
+	Version string `json:"version,omitempty"`
 }
 
 type Remediation struct {
@@ -181,6 +198,15 @@ type DetectionDefaults struct {
 	Strength  string `json:"strength,omitempty"`  // AttackStrength e.g., MEDIUM
 }
 
+type CVSS struct {
+	Version      string  `json:"version,omitempty"`
+	Vector       string  `json:"vector,omitempty"`
+	BaseScore    float64 `json:"baseScore"`
+	BaseSeverity string  `json:"baseSeverity,omitempty"`
+	Source       string  `json:"source,omitempty"`
+	Rationale    string  `json:"rationale,omitempty"`
+}
+
 const (
 	DefinitionOriginTool   = "tool"
 	DefinitionOriginCustom = "custom"
@@ -195,6 +221,7 @@ type Definition struct {
 	Description  string       `json:"description,omitempty"` // human-readable "what is this vulnerability" from the scanner
 	WASCID       int          `json:"wascid,omitempty"`
 	Taxonomy     *Taxonomy    `json:"taxonomy,omitempty"`
+	CVSS         *CVSS        `json:"cvss,omitempty"`
 	Remediation  *Remediation `json:"remediation,omitempty"`
 	Detection    *Detection   `json:"detection,omitempty"`
 	// EpicRef is the Jira Epic issue key (e.g. "SEC-12") that groups all

--- a/zap-kb/internal/entities/merge.go
+++ b/zap-kb/internal/entities/merge.go
@@ -284,6 +284,9 @@ func mergeCore(base, add EntitiesFile, policy config.TriagePolicy) EntitiesFile 
 				if bd.Taxonomy.CWEID == 0 && nd.Taxonomy.CWEID != 0 {
 					bd.Taxonomy.CWEID = nd.Taxonomy.CWEID
 				}
+				if bd.Taxonomy.CWEName == "" && nd.Taxonomy.CWEName != "" {
+					bd.Taxonomy.CWEName = nd.Taxonomy.CWEName
+				}
 				if bd.Taxonomy.CWEURI == "" && nd.Taxonomy.CWEURI != "" {
 					bd.Taxonomy.CWEURI = nd.Taxonomy.CWEURI
 				}
@@ -292,8 +295,14 @@ func mergeCore(base, add EntitiesFile, policy config.TriagePolicy) EntitiesFile 
 					copy(cp, nd.Taxonomy.CAPECIDs)
 					bd.Taxonomy.CAPECIDs = cp
 				}
+				for _, ref := range nd.Taxonomy.CAPEC {
+					upsertTaxonomyRef(&bd.Taxonomy.CAPEC, ref)
+				}
 				if len(bd.Taxonomy.ATTACK) == 0 && len(nd.Taxonomy.ATTACK) > 0 {
 					bd.Taxonomy.ATTACK = append([]string(nil), nd.Taxonomy.ATTACK...)
+				}
+				for _, ref := range nd.Taxonomy.ATTACKTechniques {
+					upsertTaxonomyRef(&bd.Taxonomy.ATTACKTechniques, ref)
 				}
 				if len(bd.Taxonomy.OWASPTop10) == 0 && len(nd.Taxonomy.OWASPTop10) > 0 {
 					bd.Taxonomy.OWASPTop10 = append([]string(nil), nd.Taxonomy.OWASPTop10...)
@@ -302,6 +311,16 @@ func mergeCore(base, add EntitiesFile, policy config.TriagePolicy) EntitiesFile 
 					bd.Taxonomy.NIST80053 = append([]string(nil), nd.Taxonomy.NIST80053...)
 				}
 				bd.Taxonomy.Tags = unionStrings(bd.Taxonomy.Tags, nd.Taxonomy.Tags)
+				if bd.Taxonomy.MappingConfidence == "" && nd.Taxonomy.MappingConfidence != "" {
+					bd.Taxonomy.MappingConfidence = nd.Taxonomy.MappingConfidence
+				}
+				for _, src := range nd.Taxonomy.Sources {
+					addTaxonomySource(bd.Taxonomy, src)
+				}
+			}
+			if bd.CVSS == nil && nd.CVSS != nil {
+				cvss := *nd.CVSS
+				bd.CVSS = &cvss
 			}
 			// Fill remediation if missing
 			if bd.Remediation == nil && nd.Remediation != nil {

--- a/zap-kb/internal/entities/mitre_enrich.go
+++ b/zap-kb/internal/entities/mitre_enrich.go
@@ -1,0 +1,183 @@
+package entities
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Warlockobama/DevSecOpsKB/zap-kb/internal/zapmeta"
+)
+
+// EnrichMITRE expands existing CWE, CAPEC, and ATT&CK identifiers with
+// MITRE-maintained titles, canonical URLs, source attribution, and mapping
+// confidence. It is offline and best-effort; it never overwrites analyst data.
+func EnrichMITRE(defs []Definition) {
+	for i := range defs {
+		d := &defs[i]
+		if d.Taxonomy == nil {
+			continue
+		}
+		t := d.Taxonomy
+
+		if t.CWEID > 0 {
+			if ref := zapmeta.LookupCWEInfo(t.CWEID); ref != nil {
+				if strings.TrimSpace(t.CWEName) == "" {
+					t.CWEName = ref.Name
+				}
+				if strings.TrimSpace(t.CWEURI) == "" {
+					t.CWEURI = ref.URL
+				}
+				addTaxonomySource(t, TaxonomySource{Name: ref.Source, URL: ref.URL})
+			}
+		}
+
+		for _, id := range t.CAPECIDs {
+			if ref := zapmeta.LookupCAPECInfo(id); ref != nil {
+				upsertTaxonomyRef(&t.CAPEC, TaxonomyRef{ID: ref.ID, Name: ref.Name, URL: ref.URL})
+				addTaxonomySource(t, TaxonomySource{Name: ref.Source, URL: ref.URL})
+			}
+		}
+
+		for _, id := range t.ATTACK {
+			if ref := zapmeta.LookupATTACKInfo(id); ref != nil {
+				upsertTaxonomyRef(&t.ATTACKTechniques, TaxonomyRef{ID: ref.ID, Name: ref.Name, URL: ref.URL})
+				addTaxonomySource(t, TaxonomySource{Name: ref.Source, URL: ref.URL})
+			}
+		}
+
+		if strings.TrimSpace(t.MappingConfidence) == "" {
+			switch {
+			case len(t.ATTACK) > 0:
+				t.MappingConfidence = "curated"
+			case len(t.CAPECIDs) > 0:
+				t.MappingConfidence = "curated-cwe-derived"
+			case t.CWEID > 0:
+				t.MappingConfidence = "scanner-cwe"
+			}
+		}
+	}
+}
+
+// EnrichCVSS estimates definition-level CVSS when no official score is present.
+// Scanner findings are weakness-based rather than CVE-based, so this intentionally
+// records the source and rationale as estimated.
+func EnrichCVSS(ef *EntitiesFile) {
+	if ef == nil {
+		return
+	}
+	maxRiskByDef := map[string]int{}
+	riskSeenByDef := map[string]bool{}
+	for _, f := range ef.Findings {
+		rank, ok := riskRank(f.Risk, f.RiskCode)
+		if !ok {
+			continue
+		}
+		if !riskSeenByDef[f.DefinitionID] || rank > maxRiskByDef[f.DefinitionID] {
+			maxRiskByDef[f.DefinitionID] = rank
+		}
+		riskSeenByDef[f.DefinitionID] = true
+	}
+	for _, o := range ef.Occurrences {
+		rank, ok := riskRank(o.Risk, o.RiskCode)
+		if !ok {
+			continue
+		}
+		if !riskSeenByDef[o.DefinitionID] || rank > maxRiskByDef[o.DefinitionID] {
+			maxRiskByDef[o.DefinitionID] = rank
+		}
+		riskSeenByDef[o.DefinitionID] = true
+	}
+
+	for i := range ef.Definitions {
+		d := &ef.Definitions[i]
+		if d.CVSS != nil || !riskSeenByDef[d.DefinitionID] {
+			continue
+		}
+		d.CVSS = estimatedCVSS(maxRiskByDef[d.DefinitionID])
+	}
+}
+
+func upsertTaxonomyRef(refs *[]TaxonomyRef, ref TaxonomyRef) {
+	id := strings.ToUpper(strings.TrimSpace(ref.ID))
+	if id == "" {
+		return
+	}
+	for i := range *refs {
+		if strings.EqualFold(strings.TrimSpace((*refs)[i].ID), id) {
+			if strings.TrimSpace((*refs)[i].Name) == "" {
+				(*refs)[i].Name = ref.Name
+			}
+			if strings.TrimSpace((*refs)[i].URL) == "" {
+				(*refs)[i].URL = ref.URL
+			}
+			return
+		}
+	}
+	ref.ID = id
+	*refs = append(*refs, ref)
+}
+
+func addTaxonomySource(t *Taxonomy, src TaxonomySource) {
+	if t == nil || strings.TrimSpace(src.Name) == "" {
+		return
+	}
+	src.Name = strings.TrimSpace(src.Name)
+	src.URL = strings.TrimSpace(src.URL)
+	src.Version = strings.TrimSpace(src.Version)
+	for _, existing := range t.Sources {
+		if strings.EqualFold(strings.TrimSpace(existing.Name), src.Name) &&
+			strings.EqualFold(strings.TrimSpace(existing.URL), src.URL) {
+			return
+		}
+	}
+	t.Sources = append(t.Sources, src)
+}
+
+func riskRank(risk, riskCode string) (int, bool) {
+	r := strings.ToLower(strings.TrimSpace(risk))
+	if r == "" {
+		r = strings.ToLower(strings.TrimSpace(riskCode))
+	}
+	switch r {
+	case "3", "high":
+		return 3, true
+	case "2", "medium":
+		return 2, true
+	case "1", "low":
+		return 1, true
+	case "0", "info", "informational":
+		return 0, true
+	default:
+		return 0, false
+	}
+}
+
+func estimatedCVSS(rank int) *CVSS {
+	cvss := &CVSS{
+		Version:   "3.1",
+		Source:    "devsecopskb-estimated",
+		Rationale: "Estimated from scanner risk because this finding is weakness-based, not CVE-based.",
+	}
+	switch rank {
+	case 3:
+		cvss.Vector = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:N"
+		cvss.BaseScore = 8.2
+		cvss.BaseSeverity = "HIGH"
+	case 2:
+		cvss.Vector = "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N"
+		cvss.BaseScore = 6.1
+		cvss.BaseSeverity = "MEDIUM"
+	case 1:
+		cvss.Vector = "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:N/A:N"
+		cvss.BaseScore = 3.1
+		cvss.BaseSeverity = "LOW"
+	default:
+		cvss.Vector = "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:N/A:N"
+		cvss.BaseSeverity = "NONE"
+	}
+	if cvss.BaseScore > 0 {
+		cvss.BaseSeverity = strings.ToUpper(cvss.BaseSeverity)
+	} else if strings.TrimSpace(cvss.BaseSeverity) == "" {
+		cvss.BaseSeverity = fmt.Sprintf("RANK-%d", rank)
+	}
+	return cvss
+}

--- a/zap-kb/internal/entities/mitre_enrich_test.go
+++ b/zap-kb/internal/entities/mitre_enrich_test.go
@@ -1,0 +1,136 @@
+package entities
+
+import "testing"
+
+func TestEnrichMITREExpandsCWEAndCAPEC(t *testing.T) {
+	defs := []Definition{
+		{
+			DefinitionID: "def-sql",
+			Taxonomy: &Taxonomy{
+				CWEID:    89,
+				CAPECIDs: []int{66},
+			},
+		},
+	}
+
+	EnrichMITRE(defs)
+
+	tax := defs[0].Taxonomy
+	if tax.CWEName == "" {
+		t.Fatal("expected CWEName to be populated")
+	}
+	if tax.CWEURI != "https://cwe.mitre.org/data/definitions/89.html" {
+		t.Fatalf("CWEURI = %q", tax.CWEURI)
+	}
+	if len(tax.CAPEC) != 1 || tax.CAPEC[0].ID != "CAPEC-66" {
+		t.Fatalf("CAPEC refs = %+v, want CAPEC-66", tax.CAPEC)
+	}
+	if tax.MappingConfidence != "curated-cwe-derived" {
+		t.Fatalf("MappingConfidence = %q", tax.MappingConfidence)
+	}
+	if len(tax.Sources) == 0 {
+		t.Fatal("expected MITRE sources to be recorded")
+	}
+}
+
+func TestEnrichMITREExpandsATTACK(t *testing.T) {
+	defs := []Definition{
+		{
+			DefinitionID: "def-custom",
+			Taxonomy: &Taxonomy{
+				ATTACK: []string{"T1078"},
+			},
+		},
+	}
+
+	EnrichMITRE(defs)
+
+	techniques := defs[0].Taxonomy.ATTACKTechniques
+	if len(techniques) != 1 {
+		t.Fatalf("ATTACKTechniques = %+v, want one technique", techniques)
+	}
+	if techniques[0].Name != "Valid Accounts" {
+		t.Fatalf("ATTACK technique name = %q", techniques[0].Name)
+	}
+	if techniques[0].URL != "https://attack.mitre.org/techniques/T1078/" {
+		t.Fatalf("ATTACK technique URL = %q", techniques[0].URL)
+	}
+}
+
+func TestEnrichMITREDoesNotOverwriteAnalystFields(t *testing.T) {
+	defs := []Definition{
+		{
+			DefinitionID: "def-xss",
+			Taxonomy: &Taxonomy{
+				CWEID:             79,
+				CWEName:           "Custom CWE title",
+				MappingConfidence: "analyst-reviewed",
+			},
+		},
+	}
+
+	EnrichMITRE(defs)
+
+	if defs[0].Taxonomy.CWEName != "Custom CWE title" {
+		t.Fatalf("CWEName was overwritten: %q", defs[0].Taxonomy.CWEName)
+	}
+	if defs[0].Taxonomy.MappingConfidence != "analyst-reviewed" {
+		t.Fatalf("MappingConfidence was overwritten: %q", defs[0].Taxonomy.MappingConfidence)
+	}
+}
+
+func TestEnrichCVSSEstimatesFromMaxDefinitionRisk(t *testing.T) {
+	ef := &EntitiesFile{
+		Definitions: []Definition{{DefinitionID: "def-1"}},
+		Findings: []Finding{
+			{DefinitionID: "def-1", Risk: "Low"},
+			{DefinitionID: "def-1", Risk: "Medium"},
+		},
+		Occurrences: []Occurrence{
+			{DefinitionID: "def-1", Risk: "High"},
+		},
+	}
+
+	EnrichCVSS(ef)
+
+	cvss := ef.Definitions[0].CVSS
+	if cvss == nil {
+		t.Fatal("expected CVSS to be populated")
+	}
+	if cvss.BaseSeverity != "HIGH" || cvss.BaseScore != 8.2 {
+		t.Fatalf("CVSS = %+v, want HIGH 8.2", cvss)
+	}
+	if cvss.Source != "devsecopskb-estimated" {
+		t.Fatalf("CVSS source = %q", cvss.Source)
+	}
+}
+
+func TestEnrichCVSSDoesNotOverwriteExisting(t *testing.T) {
+	ef := &EntitiesFile{
+		Definitions: []Definition{
+			{
+				DefinitionID: "def-1",
+				CVSS:         &CVSS{Version: "3.1", BaseSeverity: "LOW", BaseScore: 3.1, Source: "analyst"},
+			},
+		},
+		Findings: []Finding{{DefinitionID: "def-1", Risk: "High"}},
+	}
+
+	EnrichCVSS(ef)
+
+	if ef.Definitions[0].CVSS.Source != "analyst" {
+		t.Fatalf("existing CVSS was overwritten: %+v", ef.Definitions[0].CVSS)
+	}
+}
+
+func TestEnrichCVSSLeavesDefinitionWithoutRiskAlone(t *testing.T) {
+	ef := &EntitiesFile{
+		Definitions: []Definition{{DefinitionID: "def-1"}},
+	}
+
+	EnrichCVSS(ef)
+
+	if ef.Definitions[0].CVSS != nil {
+		t.Fatalf("expected CVSS to remain nil, got %+v", ef.Definitions[0].CVSS)
+	}
+}

--- a/zap-kb/internal/output/confluence/exporter.go
+++ b/zap-kb/internal/output/confluence/exporter.go
@@ -2227,9 +2227,20 @@ func prependDefProperties(storageBody string, def *entities.Definition, jiraBase
 	if def.WASCID > 0 {
 		props = append(props, [2]string{"WASC", fmt.Sprintf("WASC-%d", def.WASCID)})
 	}
+	if def.CVSS != nil {
+		if def.CVSS.BaseScore > 0 && strings.TrimSpace(def.CVSS.BaseSeverity) != "" {
+			props = append(props, [2]string{"CVSS", fmt.Sprintf("%.1f %s", def.CVSS.BaseScore, escapeHTML(def.CVSS.BaseSeverity))})
+		} else if strings.TrimSpace(def.CVSS.BaseSeverity) != "" {
+			props = append(props, [2]string{"CVSS", escapeHTML(def.CVSS.BaseSeverity)})
+		}
+	}
 	// 4. CWE
 	if def.Taxonomy != nil && def.Taxonomy.CWEID > 0 {
-		link := fmt.Sprintf(`<a href="%s">CWE-%d</a>`, escapeAttr(def.Taxonomy.CWEURI), def.Taxonomy.CWEID)
+		label := fmt.Sprintf("CWE-%d", def.Taxonomy.CWEID)
+		if strings.TrimSpace(def.Taxonomy.CWEName) != "" {
+			label += ": " + def.Taxonomy.CWEName
+		}
+		link := fmt.Sprintf(`<a href="%s">%s</a>`, escapeAttr(def.Taxonomy.CWEURI), escapeHTML(label))
 		props = append(props, [2]string{"CWE", link})
 	}
 	// 5. OWASP — linked
@@ -2237,10 +2248,29 @@ func prependDefProperties(storageBody string, def *entities.Definition, jiraBase
 		props = append(props, [2]string{"OWASP Top 10", owaspTop10Links(def.Taxonomy.OWASPTop10)})
 	}
 	// 6. CAPEC
-	if def.Taxonomy != nil && len(def.Taxonomy.CAPECIDs) > 0 {
-		capecStrs := make([]string, len(def.Taxonomy.CAPECIDs))
-		for i, id := range def.Taxonomy.CAPECIDs {
-			capecStrs[i] = fmt.Sprintf(`<a href="https://capec.mitre.org/data/definitions/%d.html">CAPEC-%d</a>`, id, id)
+	if def.Taxonomy != nil && (len(def.Taxonomy.CAPEC) > 0 || len(def.Taxonomy.CAPECIDs) > 0) {
+		capecStrs := make([]string, 0, len(def.Taxonomy.CAPEC)+len(def.Taxonomy.CAPECIDs))
+		for _, ref := range def.Taxonomy.CAPEC {
+			label := strings.TrimSpace(ref.ID)
+			if strings.TrimSpace(ref.Name) != "" {
+				if label != "" {
+					label += ": "
+				}
+				label += strings.TrimSpace(ref.Name)
+			}
+			if label == "" {
+				label = strings.TrimSpace(ref.URL)
+			}
+			if strings.TrimSpace(ref.URL) != "" {
+				capecStrs = append(capecStrs, fmt.Sprintf(`<a href="%s">%s</a>`, escapeAttr(ref.URL), escapeHTML(label)))
+			} else if label != "" {
+				capecStrs = append(capecStrs, escapeHTML(label))
+			}
+		}
+		if len(capecStrs) == 0 {
+			for _, id := range def.Taxonomy.CAPECIDs {
+				capecStrs = append(capecStrs, fmt.Sprintf(`<a href="https://capec.mitre.org/data/definitions/%d.html">CAPEC-%d</a>`, id, id))
+			}
 		}
 		props = append(props, [2]string{"CAPEC", strings.Join(capecStrs, ", ")})
 	}
@@ -2265,7 +2295,27 @@ func prependDefProperties(storageBody string, def *entities.Definition, jiraBase
 		props = append(props, [2]string{"Source", `<a href="` + escapeAttr(src) + `">` + escapeHTML(src) + `</a>`})
 	}
 	if def.Taxonomy != nil {
-		if len(def.Taxonomy.ATTACK) > 0 {
+		if len(def.Taxonomy.ATTACKTechniques) > 0 {
+			attackStrs := make([]string, 0, len(def.Taxonomy.ATTACKTechniques))
+			for _, ref := range def.Taxonomy.ATTACKTechniques {
+				label := strings.TrimSpace(ref.ID)
+				if strings.TrimSpace(ref.Name) != "" {
+					if label != "" {
+						label += ": "
+					}
+					label += strings.TrimSpace(ref.Name)
+				}
+				if label == "" {
+					label = strings.TrimSpace(ref.URL)
+				}
+				if strings.TrimSpace(ref.URL) != "" {
+					attackStrs = append(attackStrs, fmt.Sprintf(`<a href="%s">%s</a>`, escapeAttr(ref.URL), escapeHTML(label)))
+				} else if label != "" {
+					attackStrs = append(attackStrs, escapeHTML(label))
+				}
+			}
+			props = append(props, [2]string{"ATT&CK", strings.Join(attackStrs, ", ")})
+		} else if len(def.Taxonomy.ATTACK) > 0 {
 			props = append(props, [2]string{"ATT&CK", escapeHTML(strings.Join(def.Taxonomy.ATTACK, ", "))})
 		}
 		if len(def.Taxonomy.NIST80053) > 0 {

--- a/zap-kb/internal/output/confluence/exporter_test.go
+++ b/zap-kb/internal/output/confluence/exporter_test.go
@@ -2516,9 +2516,20 @@ func TestPrependDefProperties_TaxonomyWritten(t *testing.T) {
 		PluginID:     "nuclei-sqli",
 		Alert:        "SQL Injection",
 		Taxonomy: &entities.Taxonomy{
-			CWEID:      89,
-			CWEURI:     "https://cwe.mitre.org/data/definitions/89.html",
+			CWEID:   89,
+			CWEName: "Improper Neutralization of Special Elements used in an SQL Command",
+			CWEURI:  "https://cwe.mitre.org/data/definitions/89.html",
+			CAPEC: []entities.TaxonomyRef{
+				{ID: "CAPEC-66", Name: "SQL Injection", URL: "https://capec.mitre.org/data/definitions/66.html"},
+			},
+			ATTACKTechniques: []entities.TaxonomyRef{
+				{ID: "T1190", Name: "Exploit Public-Facing Application", URL: "https://attack.mitre.org/techniques/T1190/"},
+			},
 			OWASPTop10: []string{"A03:2021"},
+		},
+		CVSS: &entities.CVSS{
+			BaseScore:    6.1,
+			BaseSeverity: "MEDIUM",
 		},
 	}
 
@@ -2529,6 +2540,11 @@ func TestPrependDefProperties_TaxonomyWritten(t *testing.T) {
 	}
 	if !strings.Contains(out, "A03") {
 		t.Errorf("def properties should contain OWASP category 'A03', got: %.500s", out)
+	}
+	for _, want := range []string{"6.1 MEDIUM", "Improper Neutralization", "CAPEC-66", "SQL Injection", "T1190", "Exploit Public-Facing Application"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("def properties should contain %q, got: %.500s", want, out)
+		}
 	}
 	if !strings.Contains(out, "BODY") {
 		t.Error("original storage body should be preserved after prepending properties")

--- a/zap-kb/internal/output/jira/adf.go
+++ b/zap-kb/internal/output/jira/adf.go
@@ -126,14 +126,7 @@ func buildDescription(f entities.Finding, def *entities.Definition, occ *entitie
 			))
 		}
 
-		// CWE link
-		if def.Taxonomy != nil && def.Taxonomy.CWEID > 0 {
-			cweURL := fmt.Sprintf("https://cwe.mitre.org/data/definitions/%d.html", def.Taxonomy.CWEID)
-			nodes = append(nodes, para(
-				textNode("CWE: "),
-				linkNode(fmt.Sprintf("CWE-%d", def.Taxonomy.CWEID), cweURL),
-			))
-		}
+		nodes = append(nodes, buildSecurityClassificationNodes(def)...)
 
 		// ZAP docs link
 		if def.Detection != nil && strings.TrimSpace(def.Detection.DocsURL) != "" {

--- a/zap-kb/internal/output/jira/adf_test.go
+++ b/zap-kb/internal/output/jira/adf_test.go
@@ -49,7 +49,25 @@ func TestBuildDescription_WithDefinition(t *testing.T) {
 		Risk:      "medium",
 	}
 	def := &entities.Definition{
-		Taxonomy: &entities.Taxonomy{CWEID: 79},
+		Taxonomy: &entities.Taxonomy{
+			CWEID:   79,
+			CWEName: "Improper Neutralization of Input During Web Page Generation",
+			CAPEC: []entities.TaxonomyRef{
+				{ID: "CAPEC-86", Name: "Cross-site Scripting", URL: "https://capec.mitre.org/data/definitions/86.html"},
+			},
+			ATTACKTechniques: []entities.TaxonomyRef{
+				{ID: "T1190", Name: "Exploit Public-Facing Application", URL: "https://attack.mitre.org/techniques/T1190/"},
+			},
+			OWASPTop10:        []string{"A03:2021"},
+			MappingConfidence: "curated",
+		},
+		CVSS: &entities.CVSS{
+			Version:      "3.1",
+			Vector:       "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N",
+			BaseScore:    6.1,
+			BaseSeverity: "MEDIUM",
+			Source:       "devsecopskb-estimated",
+		},
 		Remediation: &entities.Remediation{
 			Summary: "Encode all user input before rendering.",
 		},
@@ -63,7 +81,16 @@ func TestBuildDescription_WithDefinition(t *testing.T) {
 
 	for _, want := range []string{
 		"CWE-79",
+		"Improper Neutralization",
 		"cwe.mitre.org",
+		"CVSS:3.1",
+		"6.1 MEDIUM",
+		"CAPEC-86",
+		"Cross-site Scripting",
+		"T1190",
+		"Exploit Public-Facing Application",
+		"A03:2021",
+		"curated",
 		"Encode all user input",
 		"zaproxy.org/docs/alerts/10016",
 	} {

--- a/zap-kb/internal/output/jira/epic.go
+++ b/zap-kb/internal/output/jira/epic.go
@@ -142,13 +142,7 @@ func buildEpicDescription(def *entities.Definition, ev epicEvidence) adfDoc {
 		nodes = append(nodes, para(textNode(desc)))
 	}
 
-	if def.Taxonomy != nil && def.Taxonomy.CWEID > 0 {
-		cweURL := fmt.Sprintf("https://cwe.mitre.org/data/definitions/%d.html", def.Taxonomy.CWEID)
-		nodes = append(nodes, para(
-			textNode("CWE: "),
-			linkNode(fmt.Sprintf("CWE-%d", def.Taxonomy.CWEID), cweURL),
-		))
-	}
+	nodes = append(nodes, buildSecurityClassificationNodes(def)...)
 
 	if def.Detection != nil && strings.TrimSpace(def.Detection.DocsURL) != "" {
 		nodes = append(nodes, para(

--- a/zap-kb/internal/output/jira/epic_test.go
+++ b/zap-kb/internal/output/jira/epic_test.go
@@ -50,9 +50,23 @@ func TestBuildEpicDescription_ContainsKeyParts(t *testing.T) {
 		PluginID:     "10020",
 		Alert:        "X-Frame-Options Header Not Set",
 		Description:  "Missing header allows clickjacking.",
-		Taxonomy:     &entities.Taxonomy{CWEID: 1021},
-		Remediation:  &entities.Remediation{Summary: "Set X-Frame-Options: DENY."},
-		Detection:    &entities.Detection{DocsURL: "https://www.zaproxy.org/docs/alerts/10020/"},
+		Taxonomy: &entities.Taxonomy{
+			CWEID:   1021,
+			CWEName: "Improper Restriction of Rendered UI Layers or Frames",
+			CAPEC: []entities.TaxonomyRef{
+				{ID: "CAPEC-103", Name: "Clickjacking", URL: "https://capec.mitre.org/data/definitions/103.html"},
+			},
+			MappingConfidence: "scanner-cwe",
+		},
+		CVSS: &entities.CVSS{
+			Version:      "3.1",
+			Vector:       "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:N/A:N",
+			BaseScore:    3.1,
+			BaseSeverity: "LOW",
+			Source:       "devsecopskb-estimated",
+		},
+		Remediation: &entities.Remediation{Summary: "Set X-Frame-Options: DENY."},
+		Detection:   &entities.Detection{DocsURL: "https://www.zaproxy.org/docs/alerts/10020/"},
 	}
 	doc := buildEpicDescription(def, epicEvidence{})
 	data, err := json.Marshal(doc)
@@ -63,7 +77,13 @@ func TestBuildEpicDescription_ContainsKeyParts(t *testing.T) {
 	for _, want := range []string{
 		"Missing header allows clickjacking.",
 		"CWE-1021",
+		"Improper Restriction",
 		"cwe.mitre.org/data/definitions/1021",
+		"CVSS:3.1",
+		"3.1 LOW",
+		"CAPEC-103",
+		"Clickjacking",
+		"scanner-cwe",
 		"zaproxy.org/docs/alerts/10020",
 		"Set X-Frame-Options: DENY.",
 		"Child issues",

--- a/zap-kb/internal/output/jira/taxonomy.go
+++ b/zap-kb/internal/output/jira/taxonomy.go
@@ -1,0 +1,154 @@
+package jira
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Warlockobama/DevSecOpsKB/zap-kb/internal/entities"
+)
+
+func buildSecurityClassificationNodes(def *entities.Definition) []any {
+	if def == nil {
+		return nil
+	}
+	var nodes []any
+	if def.CVSS != nil {
+		if line := cvssLine(def.CVSS); line != "" {
+			nodes = append(nodes, para(textNode("CVSS: "+line)))
+		}
+	}
+	if def.Taxonomy == nil {
+		return nodes
+	}
+	t := def.Taxonomy
+	if t.CWEID > 0 {
+		url := strings.TrimSpace(t.CWEURI)
+		if url == "" {
+			url = fmt.Sprintf("https://cwe.mitre.org/data/definitions/%d.html", t.CWEID)
+		}
+		nodes = append(nodes, para(
+			textNode("CWE: "),
+			linkNode(cweLabel(t), url),
+		))
+	}
+	if refs := capecRefs(t); len(refs) > 0 {
+		nodes = append(nodes, taxonomyRefParagraph("CAPEC", refs))
+	}
+	if refs := attackRefs(t); len(refs) > 0 {
+		nodes = append(nodes, taxonomyRefParagraph("ATT&CK", refs))
+	}
+	if vals := trimmed(t.OWASPTop10); len(vals) > 0 {
+		nodes = append(nodes, para(textNode("OWASP Top 10: "+strings.Join(vals, ", "))))
+	}
+	if confidence := strings.TrimSpace(t.MappingConfidence); confidence != "" {
+		nodes = append(nodes, para(textNode("Mapping confidence: "+confidence)))
+	}
+	return nodes
+}
+
+func cvssLine(cvss *entities.CVSS) string {
+	if cvss == nil {
+		return ""
+	}
+	parts := []string{}
+	if cvss.BaseScore > 0 || strings.TrimSpace(cvss.BaseSeverity) != "" {
+		score := fmt.Sprintf("%.1f", cvss.BaseScore)
+		if strings.TrimSpace(cvss.BaseSeverity) != "" {
+			score += " " + strings.TrimSpace(cvss.BaseSeverity)
+		}
+		parts = append(parts, score)
+	}
+	if strings.TrimSpace(cvss.Vector) != "" {
+		parts = append(parts, strings.TrimSpace(cvss.Vector))
+	}
+	if strings.TrimSpace(cvss.Source) != "" {
+		parts = append(parts, "source: "+strings.TrimSpace(cvss.Source))
+	}
+	return strings.Join(parts, " | ")
+}
+
+func cweLabel(t *entities.Taxonomy) string {
+	label := fmt.Sprintf("CWE-%d", t.CWEID)
+	if strings.TrimSpace(t.CWEName) != "" {
+		label += ": " + strings.TrimSpace(t.CWEName)
+	}
+	return label
+}
+
+func capecRefs(t *entities.Taxonomy) []entities.TaxonomyRef {
+	if len(t.CAPEC) > 0 {
+		return t.CAPEC
+	}
+	refs := make([]entities.TaxonomyRef, 0, len(t.CAPECIDs))
+	for _, id := range t.CAPECIDs {
+		if id <= 0 {
+			continue
+		}
+		refs = append(refs, entities.TaxonomyRef{
+			ID:  fmt.Sprintf("CAPEC-%d", id),
+			URL: fmt.Sprintf("https://capec.mitre.org/data/definitions/%d.html", id),
+		})
+	}
+	return refs
+}
+
+func attackRefs(t *entities.Taxonomy) []entities.TaxonomyRef {
+	if len(t.ATTACKTechniques) > 0 {
+		return t.ATTACKTechniques
+	}
+	refs := make([]entities.TaxonomyRef, 0, len(t.ATTACK))
+	for _, id := range t.ATTACK {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		refs = append(refs, entities.TaxonomyRef{ID: id})
+	}
+	return refs
+}
+
+func taxonomyRefParagraph(label string, refs []entities.TaxonomyRef) adfParagraph {
+	nodes := []any{textNode(label + ": ")}
+	wrote := false
+	for _, ref := range refs {
+		display := taxonomyRefLabel(ref)
+		if display == "" {
+			continue
+		}
+		if wrote {
+			nodes = append(nodes, textNode(", "))
+		}
+		if url := strings.TrimSpace(ref.URL); url != "" {
+			nodes = append(nodes, linkNode(display, url))
+		} else {
+			nodes = append(nodes, textNode(display))
+		}
+		wrote = true
+	}
+	return para(nodes...)
+}
+
+func taxonomyRefLabel(ref entities.TaxonomyRef) string {
+	id := strings.TrimSpace(ref.ID)
+	name := strings.TrimSpace(ref.Name)
+	switch {
+	case id != "" && name != "":
+		return id + ": " + name
+	case id != "":
+		return id
+	case name != "":
+		return name
+	default:
+		return strings.TrimSpace(ref.URL)
+	}
+}
+
+func trimmed(vals []string) []string {
+	out := make([]string, 0, len(vals))
+	for _, val := range vals {
+		if s := strings.TrimSpace(val); s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}

--- a/zap-kb/internal/output/jsondump/jsondump.go
+++ b/zap-kb/internal/output/jsondump/jsondump.go
@@ -47,8 +47,22 @@ func WritePretty(path string, v any) error {
 	// Atomic rename — on POSIX this is guaranteed atomic; on Windows NTFS it is
 	// effectively atomic (os.Rename uses MoveFileEx with REPLACE_EXISTING).
 	if err := os.Rename(tmpName, path); err != nil {
-		return fmt.Errorf("jsondump: rename: %w", err)
+		if fallbackErr := writePrettyFallback(tmpName, path); fallbackErr != nil {
+			return fmt.Errorf("jsondump: rename: %w; fallback write: %v", err, fallbackErr)
+		}
+		_ = os.Remove(tmpName)
 	}
 	success = true
+	return nil
+}
+
+func writePrettyFallback(tmpName, path string) error {
+	b, err := os.ReadFile(tmpName)
+	if err != nil {
+		return fmt.Errorf("read temp: %w", err)
+	}
+	if err := os.WriteFile(path, b, 0o600); err != nil {
+		return fmt.Errorf("write target: %w", err)
+	}
 	return nil
 }

--- a/zap-kb/internal/output/obsidian/obsidian.go
+++ b/zap-kb/internal/output/obsidian/obsidian.go
@@ -312,14 +312,23 @@ func WriteVault(root string, ef entities.EntitiesFile, opts Options) error {
 			if d.Taxonomy.CWEID > 0 {
 				kv["cweId"] = fmt.Sprintf("%d", d.Taxonomy.CWEID)
 			}
+			if strings.TrimSpace(d.Taxonomy.CWEName) != "" {
+				kv["cweName"] = d.Taxonomy.CWEName
+			}
 			if strings.TrimSpace(d.Taxonomy.CWEURI) != "" {
 				kv["cweUri"] = d.Taxonomy.CWEURI
 			}
 			if len(d.Taxonomy.CAPECIDs) > 0 {
 				kv["capecIds"] = intsToStrings(d.Taxonomy.CAPECIDs)
 			}
+			if vals := taxonomyRefsToStrings(d.Taxonomy.CAPEC); len(vals) > 0 {
+				kv["capec"] = vals
+			}
 			if vals := trimStrings(d.Taxonomy.ATTACK); len(vals) > 0 {
 				kv["attack"] = vals
+			}
+			if vals := taxonomyRefsToStrings(d.Taxonomy.ATTACKTechniques); len(vals) > 0 {
+				kv["attackTechniques"] = vals
 			}
 			if vals := trimStrings(d.Taxonomy.OWASPTop10); len(vals) > 0 {
 				kv["owaspTop10"] = vals
@@ -329,6 +338,27 @@ func WriteVault(root string, ef entities.EntitiesFile, opts Options) error {
 			}
 			if vals := trimStrings(d.Taxonomy.Tags); len(vals) > 0 {
 				kv["tags"] = vals
+			}
+			if strings.TrimSpace(d.Taxonomy.MappingConfidence) != "" {
+				kv["mappingConfidence"] = d.Taxonomy.MappingConfidence
+			}
+			if vals := taxonomySourcesToStrings(d.Taxonomy.Sources); len(vals) > 0 {
+				kv["taxonomySources"] = vals
+			}
+		}
+		if d.CVSS != nil {
+			if strings.TrimSpace(d.CVSS.Version) != "" {
+				kv["cvss.version"] = d.CVSS.Version
+			}
+			if strings.TrimSpace(d.CVSS.Vector) != "" {
+				kv["cvss.vector"] = d.CVSS.Vector
+			}
+			kv["cvss.baseScore"] = fmt.Sprintf("%.1f", d.CVSS.BaseScore)
+			if strings.TrimSpace(d.CVSS.BaseSeverity) != "" {
+				kv["cvss.baseSeverity"] = d.CVSS.BaseSeverity
+			}
+			if strings.TrimSpace(d.CVSS.Source) != "" {
+				kv["cvss.source"] = d.CVSS.Source
 			}
 		}
 		// definition rollup
@@ -360,16 +390,45 @@ func WriteVault(root string, ef entities.EntitiesFile, opts Options) error {
 			b.WriteString("\n")
 		}
 
+		if d.CVSS != nil {
+			b.WriteString("## CVSS\n\n")
+			if strings.TrimSpace(d.CVSS.BaseSeverity) != "" {
+				if d.CVSS.BaseScore > 0 {
+					fmt.Fprintf(&b, "- Base score: %.1f (%s)\n", d.CVSS.BaseScore, d.CVSS.BaseSeverity)
+				} else {
+					fmt.Fprintf(&b, "- Base severity: %s\n", d.CVSS.BaseSeverity)
+				}
+			}
+			if strings.TrimSpace(d.CVSS.Vector) != "" {
+				fmt.Fprintf(&b, "- Vector: `%s`\n", d.CVSS.Vector)
+			}
+			if strings.TrimSpace(d.CVSS.Source) != "" {
+				fmt.Fprintf(&b, "- Source: %s\n", d.CVSS.Source)
+			}
+			if strings.TrimSpace(d.CVSS.Rationale) != "" {
+				fmt.Fprintf(&b, "- Rationale: %s\n", d.CVSS.Rationale)
+			}
+			b.WriteString("\n")
+		}
+
 		// Taxonomy and governance tags for quick reporting/triage
 		if d.Taxonomy != nil {
 			lines := []string{}
 			if d.Taxonomy.CWEID > 0 {
-				lines = append(lines, fmt.Sprintf("CWE-%d", d.Taxonomy.CWEID))
+				cweLine := fmt.Sprintf("CWE-%d", d.Taxonomy.CWEID)
+				if strings.TrimSpace(d.Taxonomy.CWEName) != "" {
+					cweLine += ": " + d.Taxonomy.CWEName
+				}
+				lines = append(lines, cweLine)
 			}
-			if len(d.Taxonomy.CAPECIDs) > 0 {
+			if vals := taxonomyRefsToStrings(d.Taxonomy.CAPEC); len(vals) > 0 {
+				lines = append(lines, "CAPEC: "+strings.Join(vals, ", "))
+			} else if len(d.Taxonomy.CAPECIDs) > 0 {
 				lines = append(lines, fmt.Sprintf("CAPEC: %s", strings.Join(intsToStrings(d.Taxonomy.CAPECIDs), ", ")))
 			}
-			if vals := trimStrings(d.Taxonomy.ATTACK); len(vals) > 0 {
+			if vals := taxonomyRefsToStrings(d.Taxonomy.ATTACKTechniques); len(vals) > 0 {
+				lines = append(lines, "ATT&CK: "+strings.Join(vals, ", "))
+			} else if vals := trimStrings(d.Taxonomy.ATTACK); len(vals) > 0 {
 				lines = append(lines, "ATT&CK: "+strings.Join(vals, ", "))
 			}
 			if vals := trimStrings(d.Taxonomy.OWASPTop10); len(vals) > 0 {
@@ -380,6 +439,12 @@ func WriteVault(root string, ef entities.EntitiesFile, opts Options) error {
 			}
 			if vals := trimStrings(d.Taxonomy.Tags); len(vals) > 0 {
 				lines = append(lines, "Tags: "+strings.Join(vals, ", "))
+			}
+			if strings.TrimSpace(d.Taxonomy.MappingConfidence) != "" {
+				lines = append(lines, "Mapping confidence: "+d.Taxonomy.MappingConfidence)
+			}
+			if vals := taxonomySourcesToStrings(d.Taxonomy.Sources); len(vals) > 0 {
+				lines = append(lines, "Sources: "+strings.Join(vals, ", "))
 			}
 			if len(lines) > 0 {
 				b.WriteString("## Taxonomy\n\n")
@@ -3255,6 +3320,63 @@ func intsToStrings(nums []int) []string {
 	out := make([]string, 0, len(nums))
 	for _, n := range nums {
 		out = append(out, fmt.Sprintf("%d", n))
+	}
+	return out
+}
+
+func taxonomyRefsToStrings(refs []entities.TaxonomyRef) []string {
+	out := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		id := strings.TrimSpace(ref.ID)
+		name := strings.TrimSpace(ref.Name)
+		url := strings.TrimSpace(ref.URL)
+		if id == "" && name == "" && url == "" {
+			continue
+		}
+		label := ""
+		if id != "" && name != "" {
+			label = id + ": " + name
+		}
+		if id != "" && name == "" {
+			label = id
+		}
+		if id == "" && name != "" {
+			label = name
+		}
+		if label == "" {
+			label = url
+		}
+		if url != "" {
+			label = label + " (" + url + ")"
+		}
+		out = append(out, label)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func taxonomySourcesToStrings(sources []entities.TaxonomySource) []string {
+	out := make([]string, 0, len(sources))
+	for _, src := range sources {
+		name := strings.TrimSpace(src.Name)
+		url := strings.TrimSpace(src.URL)
+		version := strings.TrimSpace(src.Version)
+		if name == "" && url == "" {
+			continue
+		}
+		label := firstNonEmpty(name, url)
+		if version != "" {
+			label += " " + version
+		}
+		if url != "" && url != label {
+			label += " (" + url + ")"
+		}
+		out = append(out, label)
+	}
+	if len(out) == 0 {
+		return nil
 	}
 	return out
 }

--- a/zap-kb/internal/output/obsidian/obsidian_test.go
+++ b/zap-kb/internal/output/obsidian/obsidian_test.go
@@ -394,6 +394,65 @@ func TestWriteVault_HappyPath(t *testing.T) {
 	}
 }
 
+func TestWriteVault_DefinitionRendersCVSSAndMITRETaxonomy(t *testing.T) {
+	root := t.TempDir()
+	ef := minimalEF("occ-taxonomy")
+	ef.Definitions[0].Taxonomy = &entities.Taxonomy{
+		CWEID:   89,
+		CWEName: "Improper Neutralization of Special Elements used in an SQL Command",
+		CWEURI:  "https://cwe.mitre.org/data/definitions/89.html",
+		CAPEC: []entities.TaxonomyRef{
+			{ID: "CAPEC-66", Name: "SQL Injection", URL: "https://capec.mitre.org/data/definitions/66.html"},
+		},
+		ATTACKTechniques: []entities.TaxonomyRef{
+			{ID: "T1190", Name: "Exploit Public-Facing Application", URL: "https://attack.mitre.org/techniques/T1190/"},
+		},
+		OWASPTop10:        []string{"A03:2021"},
+		MappingConfidence: "curated-cwe-derived",
+		Sources: []entities.TaxonomySource{
+			{Name: "MITRE CWE", URL: "https://cwe.mitre.org/data/definitions/89.html"},
+		},
+	}
+	ef.Definitions[0].CVSS = &entities.CVSS{
+		Version:      "3.1",
+		Vector:       "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N",
+		BaseScore:    6.1,
+		BaseSeverity: "MEDIUM",
+		Source:       "devsecopskb-estimated",
+		Rationale:    "Estimated from scanner risk.",
+	}
+
+	if err := WriteVault(root, ef, Options{}); err != nil {
+		t.Fatalf("WriteVault: %v", err)
+	}
+	entries, err := os.ReadDir(filepath.Join(root, "definitions"))
+	if err != nil {
+		t.Fatalf("ReadDir definitions: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("expected definition page")
+	}
+	data, err := os.ReadFile(filepath.Join(root, "definitions", entries[0].Name()))
+	if err != nil {
+		t.Fatalf("ReadFile definition: %v", err)
+	}
+	body := string(data)
+	for _, want := range []string{
+		"cvss.baseScore: \"6.1\"",
+		"## CVSS",
+		"Base score: 6.1 (MEDIUM)",
+		"CWE-89: Improper Neutralization",
+		"CAPEC-66: SQL Injection",
+		"T1190: Exploit Public-Facing Application",
+		"Mapping confidence: curated-cwe-derived",
+		"MITRE CWE",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("definition page missing %q:\n%s", want, body)
+		}
+	}
+}
+
 // --- Story: TriageGuidanceFn injection ---
 
 // TestWriteVault_TriageGuidanceFn_InjectsSection verifies that when

--- a/zap-kb/internal/output/obsidian/report.go
+++ b/zap-kb/internal/output/obsidian/report.go
@@ -1,9 +1,15 @@
 package obsidian
 
-import "time"
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
 
 // ReportOptions controls generation of a time-bounded markdown report from an Obsidian vault.
-// The current stub exists to satisfy CLI wiring; full implementation can be restored when needed.
 type ReportOptions struct {
 	OutPath   string
 	Title     string
@@ -12,8 +18,185 @@ type ReportOptions struct {
 	ScanLabel string
 }
 
-// GenerateReport is a placeholder to keep CLI buildable when report generation is not enabled.
-// It can be replaced with the full implementation later.
+type reportOccurrence struct {
+	ID         string
+	FindingID  string
+	Method     string
+	URL        string
+	Risk       string
+	Status     string
+	Domain     string
+	ScanLabel  string
+	ObservedAt time.Time
+}
+
 func GenerateReport(root string, opts ReportOptions) error {
-	return nil
+	outPath := strings.TrimSpace(opts.OutPath)
+	if outPath == "" {
+		return fmt.Errorf("report out path is required")
+	}
+	if !filepath.IsAbs(outPath) {
+		outPath = filepath.Join(root, outPath)
+	}
+
+	occs, err := loadReportOccurrences(filepath.Join(root, "occurrences"), opts)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(outPath, []byte(renderReport(opts, occs)), 0o644)
+}
+
+func loadReportOccurrences(occDir string, opts ReportOptions) ([]reportOccurrence, error) {
+	entries, err := os.ReadDir(occDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read occurrences: %w", err)
+	}
+
+	var occs []reportOccurrence
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".md") {
+			continue
+		}
+		b, err := os.ReadFile(filepath.Join(occDir, entry.Name()))
+		if err != nil {
+			return nil, fmt.Errorf("read occurrence %s: %w", entry.Name(), err)
+		}
+		y := extractFrontmatter(string(b))
+		observed, ok := parseReportTime(y["observedAt"])
+		if !ok {
+			continue
+		}
+		if !opts.Since.IsZero() && observed.Before(opts.Since) {
+			continue
+		}
+		if !opts.Until.IsZero() && observed.After(opts.Until) {
+			continue
+		}
+		scan := strings.TrimSpace(y["scan.label"])
+		if strings.TrimSpace(opts.ScanLabel) != "" && scan != strings.TrimSpace(opts.ScanLabel) {
+			continue
+		}
+		status := strings.TrimSpace(y["analyst.status"])
+		if status == "" {
+			status = "open"
+		}
+		occs = append(occs, reportOccurrence{
+			ID:         firstNonEmpty(y["occurrenceId"], strings.TrimPrefix(y["id"], "occurrence/")),
+			FindingID:  y["findingId"],
+			Method:     y["method"],
+			URL:        y["url"],
+			Risk:       firstNonEmpty(y["risk"], y["riskCode"]),
+			Status:     status,
+			Domain:     y["domain"],
+			ScanLabel:  scan,
+			ObservedAt: observed,
+		})
+	}
+	sort.Slice(occs, func(i, j int) bool {
+		if occs[i].ObservedAt.Equal(occs[j].ObservedAt) {
+			return occs[i].ID < occs[j].ID
+		}
+		return occs[i].ObservedAt.After(occs[j].ObservedAt)
+	})
+	return occs, nil
+}
+
+func renderReport(opts ReportOptions, occs []reportOccurrence) string {
+	title := strings.TrimSpace(opts.Title)
+	if title == "" {
+		title = "Security Findings Report"
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "# %s\n\n", title)
+	if !opts.Since.IsZero() || !opts.Until.IsZero() {
+		fmt.Fprintf(&b, "- Window: %s to %s\n", formatReportTime(opts.Since), formatReportTime(opts.Until))
+	}
+	if strings.TrimSpace(opts.ScanLabel) != "" {
+		fmt.Fprintf(&b, "- Scan: %s\n", strings.TrimSpace(opts.ScanLabel))
+	}
+	fmt.Fprintf(&b, "- Occurrences: %d\n\n", len(occs))
+
+	writeReportCounts(&b, "Severity", occs, func(o reportOccurrence) string { return normalizeReportBucket(o.Risk) })
+	writeReportCounts(&b, "Status", occs, func(o reportOccurrence) string { return normalizeReportBucket(o.Status) })
+	writeReportCounts(&b, "Domain", occs, func(o reportOccurrence) string { return firstNonEmpty(o.Domain, "unknown") })
+
+	b.WriteString("## Occurrences\n\n")
+	if len(occs) == 0 {
+		b.WriteString("_No occurrences matched the selected window._\n")
+		return b.String()
+	}
+	b.WriteString("| Observed | Severity | Status | Endpoint | Finding |\n")
+	b.WriteString("|---|---:|---|---|---|\n")
+	for _, o := range occs {
+		endpoint := strings.TrimSpace(strings.TrimSpace(o.Method) + " " + strings.TrimSpace(o.URL))
+		fmt.Fprintf(&b, "| %s | %s | %s | %s | %s |\n",
+			o.ObservedAt.Format(time.RFC3339),
+			escapeTable(o.Risk),
+			escapeTable(o.Status),
+			escapeTable(endpoint),
+			escapeTable(o.FindingID),
+		)
+	}
+	return b.String()
+}
+
+func writeReportCounts(b *strings.Builder, title string, occs []reportOccurrence, bucket func(reportOccurrence) string) {
+	counts := map[string]int{}
+	for _, o := range occs {
+		counts[bucket(o)]++
+	}
+	keys := make([]string, 0, len(counts))
+	for k := range counts {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	fmt.Fprintf(b, "## By %s\n\n", title)
+	if len(keys) == 0 {
+		b.WriteString("_No data._\n\n")
+		return
+	}
+	b.WriteString("| Value | Count |\n")
+	b.WriteString("|---|---:|\n")
+	for _, k := range keys {
+		fmt.Fprintf(b, "| %s | %d |\n", escapeTable(k), counts[k])
+	}
+	b.WriteString("\n")
+}
+
+func parseReportTime(raw string) (time.Time, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return time.Time{}, false
+	}
+	for _, layout := range []string{time.RFC3339, "2006-01-02"} {
+		if t, err := time.Parse(layout, raw); err == nil {
+			return t.UTC(), true
+		}
+	}
+	return time.Time{}, false
+}
+
+func formatReportTime(t time.Time) string {
+	if t.IsZero() {
+		return "unbounded"
+	}
+	return t.UTC().Format(time.RFC3339)
+}
+
+func normalizeReportBucket(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "unknown"
+	}
+	return strings.ToLower(s)
+}
+
+func escapeTable(s string) string {
+	return strings.ReplaceAll(strings.TrimSpace(s), "|", "\\|")
 }

--- a/zap-kb/internal/output/obsidian/report_test.go
+++ b/zap-kb/internal/output/obsidian/report_test.go
@@ -1,0 +1,63 @@
+package obsidian
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestGenerateReportWritesRelativeToVaultAndFilters(t *testing.T) {
+	root := t.TempDir()
+	occDir := filepath.Join(root, "occurrences")
+	if err := os.MkdirAll(occDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeOccurrence := func(name, observed, scan, risk string) {
+		t.Helper()
+		body := `---
+analyst.status: "open"
+domain: "example.test"
+findingId: "fin-` + name + `"
+method: "GET"
+observedAt: "` + observed + `"
+occurrenceId: "occ-` + name + `"
+risk: "` + risk + `"
+scan.label: "` + scan + `"
+url: "https://example.test/` + name + `"
+---
+`
+		if err := os.WriteFile(filepath.Join(occDir, name+".md"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeOccurrence("in", "2026-01-02T00:00:00Z", "scan-a", "Medium")
+	writeOccurrence("wrong-scan", "2026-01-02T00:00:00Z", "scan-b", "High")
+	writeOccurrence("old", "2025-12-31T00:00:00Z", "scan-a", "Low")
+
+	err := GenerateReport(root, ReportOptions{
+		OutPath:   "reports/smoke.md",
+		Title:     "Smoke Report",
+		Since:     time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		Until:     time.Date(2026, 1, 3, 0, 0, 0, 0, time.UTC),
+		ScanLabel: "scan-a",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	b, err := os.ReadFile(filepath.Join(root, "reports", "smoke.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(b)
+	for _, want := range []string{"# Smoke Report", "- Occurrences: 1", "## Occurrences", "fin-in", "Medium"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("report missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "fin-wrong-scan") || strings.Contains(got, "fin-old") {
+		t.Fatalf("report included filtered occurrence:\n%s", got)
+	}
+}

--- a/zap-kb/internal/zapmeta/mitre.go
+++ b/zap-kb/internal/zapmeta/mitre.go
@@ -1,0 +1,130 @@
+package zapmeta
+
+import (
+	"fmt"
+	"strings"
+)
+
+// MITRERef is a small, curated offline reference to MITRE-maintained catalogs.
+// It intentionally stores titles and canonical URLs only; live catalog adapters
+// can replace or extend this later without changing the entity schema.
+type MITRERef struct {
+	ID     string
+	Name   string
+	URL    string
+	Source string
+}
+
+func CWEURL(id int) string {
+	if id <= 0 {
+		return ""
+	}
+	return fmt.Sprintf("https://cwe.mitre.org/data/definitions/%d.html", id)
+}
+
+func CAPECURL(id int) string {
+	if id <= 0 {
+		return ""
+	}
+	return fmt.Sprintf("https://capec.mitre.org/data/definitions/%d.html", id)
+}
+
+func ATTACKURL(id string) string {
+	id = strings.ToUpper(strings.TrimSpace(id))
+	if id == "" {
+		return ""
+	}
+	id = strings.ReplaceAll(id, ".", "/")
+	return fmt.Sprintf("https://attack.mitre.org/techniques/%s/", id)
+}
+
+func LookupCWEInfo(id int) *MITRERef {
+	name, ok := cweNames[id]
+	if !ok {
+		if id <= 0 {
+			return nil
+		}
+		name = fmt.Sprintf("CWE-%d", id)
+	}
+	return &MITRERef{
+		ID:     fmt.Sprintf("CWE-%d", id),
+		Name:   name,
+		URL:    CWEURL(id),
+		Source: "MITRE CWE",
+	}
+}
+
+func LookupCAPECInfo(id int) *MITRERef {
+	name, ok := capecNames[id]
+	if !ok {
+		if id <= 0 {
+			return nil
+		}
+		name = fmt.Sprintf("CAPEC-%d", id)
+	}
+	return &MITRERef{
+		ID:     fmt.Sprintf("CAPEC-%d", id),
+		Name:   name,
+		URL:    CAPECURL(id),
+		Source: "MITRE CAPEC",
+	}
+}
+
+func LookupATTACKInfo(id string) *MITRERef {
+	id = strings.ToUpper(strings.TrimSpace(id))
+	if id == "" {
+		return nil
+	}
+	name, ok := attackNames[id]
+	if !ok {
+		name = id
+	}
+	return &MITRERef{
+		ID:     id,
+		Name:   name,
+		URL:    ATTACKURL(id),
+		Source: "MITRE ATT&CK",
+	}
+}
+
+var cweNames = map[int]string{
+	22:   "Improper Limitation of a Pathname to a Restricted Directory",
+	79:   "Improper Neutralization of Input During Web Page Generation",
+	89:   "Improper Neutralization of Special Elements used in an SQL Command",
+	200:  "Exposure of Sensitive Information to an Unauthorized Actor",
+	209:  "Generation of Error Message Containing Sensitive Information",
+	264:  "Permissions, Privileges, and Access Controls",
+	287:  "Improper Authentication",
+	311:  "Missing Encryption of Sensitive Data",
+	312:  "Cleartext Storage of Sensitive Information",
+	319:  "Cleartext Transmission of Sensitive Information",
+	327:  "Use of a Broken or Risky Cryptographic Algorithm",
+	345:  "Insufficient Verification of Data Authenticity",
+	502:  "Deserialization of Untrusted Data",
+	525:  "Use of Web Browser Cache Containing Sensitive Information",
+	549:  "Missing Password Field Masking",
+	565:  "Reliance on Cookies without Validation and Integrity Checking",
+	614:  "Sensitive Cookie in HTTPS Session Without Secure Attribute",
+	639:  "Authorization Bypass Through User-Controlled Key",
+	693:  "Protection Mechanism Failure",
+	829:  "Inclusion of Functionality from Untrusted Control Sphere",
+	918:  "Server-Side Request Forgery",
+	942:  "Permissive Cross-domain Policy with Untrusted Domains",
+	1004: "Sensitive Cookie Without 'HttpOnly' Flag",
+	1021: "Improper Restriction of Rendered UI Layers or Frames",
+	1275: "Sensitive Cookie with Improper SameSite Attribute",
+}
+
+var capecNames = map[int]string{
+	1:   "Accessing Functionality Not Properly Constrained by ACLs",
+	37:  "Retrieve Embedded Sensitive Data",
+	66:  "SQL Injection",
+	86:  "Cross-site Scripting",
+	118: "Data Leakage Attacks",
+	122: "Privilege Abuse",
+}
+
+var attackNames = map[string]string{
+	"T1078": "Valid Accounts",
+	"T1190": "Exploit Public-Facing Application",
+}

--- a/zap-kb/testdata/alerts_smoke.json
+++ b/zap-kb/testdata/alerts_smoke.json
@@ -1,0 +1,42 @@
+[
+  {
+    "pluginId": "10021",
+    "alert": "X-Content-Type-Options Header Missing",
+    "name": "X-Content-Type-Options Header Missing",
+    "risk": "Low",
+    "riskcode": "1",
+    "confidence": "Medium",
+    "url": "https://example.test/login",
+    "method": "GET",
+    "param": "",
+    "attack": "",
+    "evidence": "",
+    "desc": "The Anti-MIME-Sniffing header X-Content-Type-Options was not set to nosniff.",
+    "solution": "Set the X-Content-Type-Options header to nosniff.",
+    "reference": "https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options",
+    "cweid": "693",
+    "wascid": "15",
+    "sourceid": "1"
+  },
+  {
+    "pluginId": "10038",
+    "alert": "Content Security Policy (CSP) Header Not Set",
+    "name": "Content Security Policy (CSP) Header Not Set",
+    "risk": "Medium",
+    "riskcode": "2",
+    "confidence": "High",
+    "url": "https://example.test/admin",
+    "method": "GET",
+    "param": "",
+    "attack": "",
+    "evidence": "",
+    "desc": "Content Security Policy is an added layer of security.",
+    "solution": "Configure a Content-Security-Policy response header.",
+    "reference": "https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP",
+    "cweid": "693",
+    "wascid": "15",
+    "sourceid": "1",
+    "requestHeader": "GET /admin HTTP/1.1\r\nHost: example.test\r\nCookie: session=redact-me\r\n\r\n",
+    "responseHeader": "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n"
+  }
+]


### PR DESCRIPTION
## Summary

- Adds default-on offline enrichment for MITRE CWE/CAPEC/ATT&CK metadata and estimated CVSS.
- Propagates enriched taxonomy and CVSS into Obsidian, Confluence, Jira findings, and detection Epics.
- Adds enrichment strategy documentation, smoke fixture, GitHub workflows, subcommand dispatch tests, and Obsidian report output coverage.

## Impact

Security findings now carry richer classification context without requiring live catalog adapters or network-dependent enrichment. Existing analyst-provided CVSS and taxonomy fields are preserved.

## Validation

- go test ./...
- go vet ./...
- Offline smoke run with testdata/alerts_smoke.json

Note: the local Go toolchain still prints a telemetry token warning in this Windows environment, but the commands exit successfully.