### PR TITLE
[codex] Address PR 84 review comments

### DIFF
--- a/zap-kb/internal/output/confluence/exporter.go
+++ b/zap-kb/internal/output/confluence/exporter.go
@@ -2240,7 +2240,7 @@ func prependDefProperties(storageBody string, def *entities.Definition, jiraBase
 		if strings.TrimSpace(def.Taxonomy.CWEName) != "" {
 			label += ": " + def.Taxonomy.CWEName
 		}
-		link := fmt.Sprintf(`<a href="%s">%s</a>`, escapeAttr(def.Taxonomy.CWEURI), escapeHTML(label))
+		link := fmt.Sprintf(`<a href="%s">%s</a>`, escapeAttr(cweURL(def.Taxonomy)), escapeHTML(label))
 		props = append(props, [2]string{"CWE", link})
 	}
 	// 5. OWASP — linked
@@ -2379,7 +2379,7 @@ func prependFindingProperties(storageBody string, f *entities.Finding, ei *entit
 
 	// 4. CWE
 	if def != nil && def.Taxonomy != nil && def.Taxonomy.CWEID > 0 {
-		link := fmt.Sprintf(`<a href="%s">CWE-%d</a>`, escapeAttr(def.Taxonomy.CWEURI), def.Taxonomy.CWEID)
+		link := fmt.Sprintf(`<a href="%s">CWE-%d</a>`, escapeAttr(cweURL(def.Taxonomy)), def.Taxonomy.CWEID)
 		props = append(props, [2]string{"CWE", link})
 	}
 
@@ -3404,7 +3404,7 @@ func prependOccurrenceProperties(storageBody string, o *entities.Occurrence, ei 
 		}
 		if def.Taxonomy != nil {
 			if def.Taxonomy.CWEID > 0 {
-				cweLink := fmt.Sprintf(`<a href="%s">CWE-%d</a>`, escapeAttr(def.Taxonomy.CWEURI), def.Taxonomy.CWEID)
+				cweLink := fmt.Sprintf(`<a href="%s">CWE-%d</a>`, escapeAttr(cweURL(def.Taxonomy)), def.Taxonomy.CWEID)
 				infoProps = append(infoProps, [2]string{"CWE", cweLink})
 			}
 			if len(def.Taxonomy.OWASPTop10) > 0 {
@@ -3561,6 +3561,16 @@ func applyLabels(ctx context.Context, client httpDoer, auth, base, pageID string
 }
 
 // --- Label builders ---
+
+func cweURL(t *entities.Taxonomy) string {
+	if t == nil || t.CWEID <= 0 {
+		return ""
+	}
+	if url := strings.TrimSpace(t.CWEURI); url != "" {
+		return url
+	}
+	return fmt.Sprintf("https://cwe.mitre.org/data/definitions/%d.html", t.CWEID)
+}
 
 func defLabels(def *entities.Definition) []string {
 	if def == nil {

--- a/zap-kb/internal/output/confluence/exporter_test.go
+++ b/zap-kb/internal/output/confluence/exporter_test.go
@@ -62,6 +62,20 @@ func TestExport_CreateNewPage(t *testing.T) {
 	}
 }
 
+func TestPrependDefProperties_CWEURLFallsBackWhenMissingURI(t *testing.T) {
+	def := &entities.Definition{
+		DefinitionID: "def-cwe-only",
+		PluginID:     "10001",
+		Alert:        "CWE Only",
+		Taxonomy:     &entities.Taxonomy{CWEID: 89},
+	}
+	out := prependDefProperties("BODY", def, "", 0)
+	want := `href="https://cwe.mitre.org/data/definitions/89.html"`
+	if !strings.Contains(out, want) {
+		t.Fatalf("expected fallback CWE URL %q, got: %.500s", want, out)
+	}
+}
+
 func TestExport_UpdateExistingPage(t *testing.T) {
 	// Search returns one existing page; PUT updates it with bumped version.
 	var gotPUT bool

--- a/zap-kb/internal/output/jira/adf_test.go
+++ b/zap-kb/internal/output/jira/adf_test.go
@@ -41,6 +41,16 @@ func TestBuildDescription_BasicFinding(t *testing.T) {
 	}
 }
 
+func TestCVSSLineSeverityOnlyOmitsZeroScore(t *testing.T) {
+	got := cvssLine(&entities.CVSS{BaseSeverity: "NONE"})
+	if got != "NONE" {
+		t.Fatalf("cvssLine severity-only = %q, want NONE", got)
+	}
+	if strings.Contains(got, "0.0") {
+		t.Fatalf("cvssLine should not render a zero score for severity-only CVSS: %q", got)
+	}
+}
+
 func TestBuildDescription_WithDefinition(t *testing.T) {
 	f := entities.Finding{
 		FindingID: "fin-xyz",

--- a/zap-kb/internal/output/jira/taxonomy.go
+++ b/zap-kb/internal/output/jira/taxonomy.go
@@ -51,12 +51,15 @@ func cvssLine(cvss *entities.CVSS) string {
 		return ""
 	}
 	parts := []string{}
-	if cvss.BaseScore > 0 || strings.TrimSpace(cvss.BaseSeverity) != "" {
+	severity := strings.TrimSpace(cvss.BaseSeverity)
+	if cvss.BaseScore > 0 {
 		score := fmt.Sprintf("%.1f", cvss.BaseScore)
-		if strings.TrimSpace(cvss.BaseSeverity) != "" {
-			score += " " + strings.TrimSpace(cvss.BaseSeverity)
+		if severity != "" {
+			score += " " + severity
 		}
 		parts = append(parts, score)
+	} else if severity != "" {
+		parts = append(parts, severity)
 	}
 	if strings.TrimSpace(cvss.Vector) != "" {
 		parts = append(parts, strings.TrimSpace(cvss.Vector))

--- a/zap-kb/internal/output/obsidian/obsidian.go
+++ b/zap-kb/internal/output/obsidian/obsidian.go
@@ -3346,7 +3346,7 @@ func taxonomyRefsToStrings(refs []entities.TaxonomyRef) []string {
 		if label == "" {
 			label = url
 		}
-		if url != "" {
+		if url != "" && url != label {
 			label = label + " (" + url + ")"
 		}
 		out = append(out, label)

--- a/zap-kb/internal/output/obsidian/obsidian_test.go
+++ b/zap-kb/internal/output/obsidian/obsidian_test.go
@@ -35,6 +35,16 @@ func minimalEF(occurrenceID string) entities.EntitiesFile {
 	}
 }
 
+func TestTaxonomyRefsToStringsURLOnlyDoesNotDuplicateURL(t *testing.T) {
+	got := taxonomyRefsToStrings([]entities.TaxonomyRef{{URL: "https://example.test/ref"}})
+	if len(got) != 1 {
+		t.Fatalf("expected one taxonomy ref string, got %v", got)
+	}
+	if got[0] != "https://example.test/ref" {
+		t.Fatalf("URL-only taxonomy ref should not duplicate URL, got %q", got[0])
+	}
+}
+
 // TestWriteVault_loadOccurrenceMeta_preservesAnalystStatus verifies that
 // analyst.status written in a first vault pass is preserved after a second
 // WriteVault call (confirming loadOccurrenceMeta runs before RemoveAll).

--- a/zap-kb/internal/output/obsidian/report.go
+++ b/zap-kb/internal/output/obsidian/report.go
@@ -38,6 +38,7 @@ func GenerateReport(root string, opts ReportOptions) error {
 	if !filepath.IsAbs(outPath) {
 		outPath = filepath.Join(root, outPath)
 	}
+	opts.Until = normalizeReportUntil(opts.Until)
 
 	occs, err := loadReportOccurrences(filepath.Join(root, "occurrences"), opts)
 	if err != nil {
@@ -50,6 +51,7 @@ func GenerateReport(root string, opts ReportOptions) error {
 }
 
 func loadReportOccurrences(occDir string, opts ReportOptions) ([]reportOccurrence, error) {
+	until := normalizeReportUntil(opts.Until)
 	entries, err := os.ReadDir(occDir)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -75,7 +77,7 @@ func loadReportOccurrences(occDir string, opts ReportOptions) ([]reportOccurrenc
 		if !opts.Since.IsZero() && observed.Before(opts.Since) {
 			continue
 		}
-		if !opts.Until.IsZero() && observed.After(opts.Until) {
+		if !until.IsZero() && observed.After(until) {
 			continue
 		}
 		scan := strings.TrimSpace(y["scan.label"])
@@ -105,6 +107,17 @@ func loadReportOccurrences(occDir string, opts ReportOptions) ([]reportOccurrenc
 		return occs[i].ObservedAt.After(occs[j].ObservedAt)
 	})
 	return occs, nil
+}
+
+func normalizeReportUntil(t time.Time) time.Time {
+	if t.IsZero() {
+		return t
+	}
+	t = t.UTC()
+	if t.Hour() == 0 && t.Minute() == 0 && t.Second() == 0 && t.Nanosecond() == 0 {
+		return t.Add(24*time.Hour - time.Nanosecond)
+	}
+	return t
 }
 
 func renderReport(opts ReportOptions, occs []reportOccurrence) string {

--- a/zap-kb/internal/output/obsidian/report_test.go
+++ b/zap-kb/internal/output/obsidian/report_test.go
@@ -61,3 +61,40 @@ url: "https://example.test/` + name + `"
 		t.Fatalf("report included filtered occurrence:\n%s", got)
 	}
 }
+
+func TestGenerateReportTreatsDateOnlyUntilAsEndOfDay(t *testing.T) {
+	root := t.TempDir()
+	occDir := filepath.Join(root, "occurrences")
+	if err := os.MkdirAll(occDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := `---
+observedAt: "2026-01-03T23:30:00Z"
+occurrenceId: "occ-end-day"
+findingId: "fin-end-day"
+risk: "Medium"
+---
+`
+	if err := os.WriteFile(filepath.Join(occDir, "end-day.md"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := GenerateReport(root, ReportOptions{
+		OutPath: "reports/window.md",
+		Since:   time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		Until:   time.Date(2026, 1, 3, 0, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(filepath.Join(root, "reports", "window.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(b), "fin-end-day") {
+		t.Fatalf("date-only until should include the full until day:\n%s", b)
+	}
+	if !strings.Contains(string(b), "- Window: 2026-01-01T00:00:00Z to 2026-01-03T23:59:59Z") {
+		t.Fatalf("displayed window should match normalized until:\n%s", b)
+	}
+}


### PR DESCRIPTION
## Summary

Addresses the four Copilot review comments left on PR #84 after it was merged:

- Treat date-only Obsidian report -report-until values as inclusive through the end of that day.
- Avoid duplicating URL-only taxonomy refs in Obsidian output.
- Render Jira CVSS severity-only values without a misleading 0.0 score.
- Fall back to canonical MITRE CWE URLs in Confluence when CWEURI is blank.

## Validation

- go test ./internal/output/obsidian
- go test ./internal/output/jira
- go test ./internal/output/confluence

Note: local Go still printed a telemetry-token warning under the sandbox, but all listed test commands exited successfully.