### PR TITLE
[codex] Make Jira the KB workflow source

### DIFF
--- a/zap-kb/cmd/zap-kb/jira_sync.go
+++ b/zap-kb/cmd/zap-kb/jira_sync.go
@@ -88,6 +88,29 @@ func mergeFindingTicketKeys(ent *entities.EntitiesFile, ticketKeys map[string]st
 	return added
 }
 
+func collectFindingTicketRefs(ent entities.EntitiesFile) map[string][]string {
+	out := make(map[string][]string)
+	for _, finding := range ent.Findings {
+		findingID := strings.TrimSpace(finding.FindingID)
+		if findingID == "" || finding.Analyst == nil {
+			continue
+		}
+		for _, ref := range finding.Analyst.TicketRefs {
+			ref = strings.TrimSpace(ref)
+			if ref == "" {
+				continue
+			}
+			if !containsString(out[findingID], ref) {
+				out[findingID] = append(out[findingID], ref)
+			}
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
 func persistJiraEntities(ctx jiraSyncContext, ent entities.EntitiesFile) (string, error) {
 	switch strings.TrimSpace(ctx.Format) {
 	case "entities":

--- a/zap-kb/cmd/zap-kb/jira_sync_test.go
+++ b/zap-kb/cmd/zap-kb/jira_sync_test.go
@@ -47,6 +47,26 @@ func TestMergeFindingTicketKeys_DedupesAndCountsAdds(t *testing.T) {
 	}
 }
 
+func TestCollectFindingTicketRefs_DedupesByFinding(t *testing.T) {
+	ent := testEntitiesFile()
+	ent.Findings[0].Analyst = &entities.Analyst{TicketRefs: []string{"SEC-1", " SEC-1 ", "https://example.atlassian.net/browse/SEC-2", ""}}
+	ent.Findings = append(ent.Findings, entities.Finding{
+		FindingID: "fin-2",
+		Analyst:   &entities.Analyst{TicketRefs: []string{"SEC-3"}},
+	})
+
+	got := collectFindingTicketRefs(ent)
+	if len(got) != 2 {
+		t.Fatalf("expected refs for 2 findings, got %#v", got)
+	}
+	if strings.Join(got["fin-1"], ",") != "SEC-1,https://example.atlassian.net/browse/SEC-2" {
+		t.Fatalf("unexpected fin-1 refs: %#v", got["fin-1"])
+	}
+	if strings.Join(got["fin-2"], ",") != "SEC-3" {
+		t.Fatalf("unexpected fin-2 refs: %#v", got["fin-2"])
+	}
+}
+
 func TestMergeDefinitionEpicRefs_SetsAndSkipsExisting(t *testing.T) {
 	ent := testEntitiesFile()
 	ent.Definitions = []entities.Definition{

--- a/zap-kb/cmd/zap-kb/main.go
+++ b/zap-kb/cmd/zap-kb/main.go
@@ -94,6 +94,7 @@ func main() {
 		jiraDetectionEpic  bool
 		jiraEpicIssueType  string
 		jiraEpicComponent  string
+		jiraSyncKBStatus   bool
 		allowAgentPublish  bool
 		allowCustomPublish bool
 	)
@@ -167,6 +168,7 @@ func main() {
 	flag.BoolVar(&jiraDetectionEpic, "jira-detection-epic", false, "Create/reuse a parent Epic per detection (definition); findings link via parent.")
 	flag.StringVar(&jiraEpicIssueType, "jira-epic-issue-type", "Epic", "Issue type for detection Epics (default: Epic; override for projects that use Initiative).")
 	flag.StringVar(&jiraEpicComponent, "jira-epic-component", "", "Optional Jira component name applied to detection Epics.")
+	flag.BoolVar(&jiraSyncKBStatus, "jira-sync-kb-status", false, "Legacy mode: write mapped Jira workflow status and assignee back into KB analyst fields. By default Jira remains the workflow source of truth and KB state is not mutated.")
 	flag.BoolVar(&allowAgentPublish, "allow-agent-publish", false, "Allow Confluence/Jira publish from sourceTool values like zap-agent (disabled by default)")
 	flag.BoolVar(&allowCustomPublish, "allow-custom-publish", false, "Allow Confluence/Jira publish when the input contains custom definitions (disabled by default)")
 	// Subcommands own their flag sets, so dispatch before parsing global flags.
@@ -193,6 +195,8 @@ func main() {
 	envFallback(&confToken, "CONFLUENCE_TOKEN")
 	envFallback(&jiraUser, "JIRA_USER")
 	envFallback(&jiraToken, "JIRA_API_TOKEN")
+	envFallback(&jiraServerID, "JIRA_SERVER_ID")
+	envFallback(&jiraServerName, "JIRA_SERVER_NAME")
 
 	// Load operator-tunable triage policy once at startup. This drives the
 	// auto-reopen gate, auto-suppression cadence, and rule-tune-scan tagging
@@ -698,19 +702,27 @@ func main() {
 				BaseURL:  jiraURL,
 				Username: jiraUser,
 				Token:    jiraToken,
+				ReadOnly: !jiraSyncKBStatus,
 			})
 			if pullErr != nil {
 				log.Printf("warning: jira status pull failed: %v", pullErr)
 			} else {
-				ent = pullRes.Updated
+				if jiraSyncKBStatus {
+					ent = pullRes.Updated
+				}
 				jiraStatusByKey = pullRes.RawStatuses
 				jiraAssigneeByKey = pullRes.RawAssignees
 				jiraStatusSynced = pullRes.SyncedAt
-				fmt.Printf("Jira pull: updated=%d unchanged=%d notfound=%d errors=%d\n",
-					pullRes.Result.Updated, pullRes.Result.Unchanged, pullRes.Result.NotFound, pullRes.Result.Errors)
+				if jiraSyncKBStatus {
+					fmt.Printf("Jira pull: updated=%d unchanged=%d notfound=%d errors=%d\n",
+						pullRes.Result.Updated, pullRes.Result.Unchanged, pullRes.Result.NotFound, pullRes.Result.Errors)
+				} else {
+					fmt.Printf("Jira pull: fetched=%d notfound=%d errors=%d (KB status write-back disabled)\n",
+						pullRes.Result.Unchanged, pullRes.Result.NotFound, pullRes.Result.Errors)
+				}
 			}
 		}
-		if !jiraDryRun && (addedTicketKeys > 0 || hasFindingTicketRefs(ent)) {
+		if !jiraDryRun && (addedTicketKeys > 0 || (jiraSyncKBStatus && hasFindingTicketRefs(ent))) {
 			var artPtr *runartifact.Artifact
 			if runInIsArtifact {
 				artPtr = &runInArtifact
@@ -759,19 +771,22 @@ func main() {
 			if err != nil {
 				log.Fatalf("%v", err)
 			}
-			if !jiraDryRun && len(sum.TicketKeys) > 0 && len(confSum.FindingLinks) > 0 {
-				linkCtx, linkCancel := context.WithTimeout(context.Background(), 5*time.Minute)
-				defer linkCancel()
-				linkSum, lerr := jira.SyncFindingEvidenceLinks(linkCtx, sum.TicketKeys, confSum.FindingLinks, jira.Options{
-					BaseURL:     jiraURL,
-					Username:    jiraUser,
-					APIToken:    jiraToken,
-					Concurrency: jiraConcurrency,
-				})
-				if lerr != nil {
-					log.Printf("warning: jira evidence link sync failed: %v", lerr)
-				} else {
-					fmt.Printf("Jira evidence links: added=%d skipped=%d errors=%d\n", linkSum.Added, linkSum.Skipped, linkSum.Errors)
+			if !jiraDryRun && len(confSum.FindingLinks) > 0 {
+				ticketRefs := collectFindingTicketRefs(ent)
+				if len(ticketRefs) > 0 {
+					linkCtx, linkCancel := context.WithTimeout(context.Background(), 5*time.Minute)
+					defer linkCancel()
+					linkSum, lerr := jira.SyncFindingEvidenceLinkRefs(linkCtx, ticketRefs, confSum.FindingLinks, jira.Options{
+						BaseURL:     jiraURL,
+						Username:    jiraUser,
+						APIToken:    jiraToken,
+						Concurrency: jiraConcurrency,
+					})
+					if lerr != nil {
+						log.Printf("warning: jira evidence link sync failed: %v", lerr)
+					} else {
+						fmt.Printf("Jira evidence links: added=%d skipped=%d errors=%d\n", linkSum.Added, linkSum.Skipped, linkSum.Errors)
+					}
 				}
 			}
 		}

--- a/zap-kb/docs/atlassian-cloud.md
+++ b/zap-kb/docs/atlassian-cloud.md
@@ -1,0 +1,40 @@
+# Atlassian Cloud References
+
+This project has published KB artifacts to Atlassian Cloud.
+
+## Entry Points
+
+- Atlassian site: `https://jameslerud.atlassian.net`
+- Confluence Cloud: `https://jameslerud.atlassian.net/wiki`
+- Jira issue URL pattern: `https://jameslerud.atlassian.net/browse/<KEY>`
+- Observed Jira project key: `KAN`
+
+## Confirmed Cloud Pages
+
+- DevSecOps home: `https://jameslerud.atlassian.net/spaces/DEVSECOPS/overview`
+- KB index, space `KB1`: `https://jameslerud.atlassian.net/spaces/KB1/pages/2850819/KB+Index`
+- KB index, space `KB2`: `https://jameslerud.atlassian.net/spaces/KB2/pages/24117249/KB+Index`
+- Definitions, space `KB1`: `https://jameslerud.atlassian.net/spaces/KB1/pages/2785490/Definitions`
+- Security Rule Definitions, space `KB2`: `https://jameslerud.atlassian.net/spaces/KB2/pages/24412161/Security+Rule+Definitions`
+
+## Confirmed Jira Access
+
+- Atlassian API identity: `james.lerud` / `james.lerud@gmail.com`
+- Visible Jira project: `KAN: DevSecOps`
+- Recent observed issues include `KAN-203`, `KAN-204`, `KAN-208`, `KAN-209`, `KAN-210`, and epics `KAN-211`, `KAN-212`, `KAN-213`.
+
+## Local Evidence
+
+These local generated files contain references to the Atlassian Cloud tenant:
+
+- `zap-kb/docs/obsidian/findings/*.md` include analyst case links such as `KAN-189`.
+- `_ext_devsecopsfiringranve/exports/kb-publish/runs/run-20260412234358-243efbf0/publish-summary.json` records:
+  - `confluence_url`: `https://jameslerud.atlassian.net/wiki`
+  - `jira_url`: `https://jameslerud.atlassian.net`
+- `_ext_devsecopsfiringranve/scripts/publish-to-confluence-via-kb.ps1` defaults `JiraUrl` to `https://jameslerud.atlassian.net`.
+
+## Notes For Future Sessions
+
+- Do not store API tokens, passwords, or Atlassian API keys in this file.
+- If browser login is needed, open Confluence Cloud at `https://jameslerud.atlassian.net/wiki`.
+- If looking for the published DevSecOps KB in Atlassian Cloud, start from Confluence search or the recent pages under the site above.

--- a/zap-kb/internal/output/confluence/exporter.go
+++ b/zap-kb/internal/output/confluence/exporter.go
@@ -3016,25 +3016,13 @@ func jiraOverviewSection(ei *entityIndex, jiraBaseURL string, jiraStatusByKey ma
 		return ""
 	}
 	var b strings.Builder
-	b.WriteString(`<h2>Linked Jira Cases</h2>`)
-	b.WriteString(`<p><em>Analyst workflow is managed in Jira. These links resolve to Jira smart cards; statuses reflect the last publish sync.</em></p>`)
+	b.WriteString(`<h2>Jira References</h2>`)
+	b.WriteString(`<p><em>Analyst workflow is managed in Jira. Use the live Jira queue for current status; this KB keeps evidence links only.</em></p>`)
 	b.WriteString(`<table><tbody>`)
-	b.WriteString(`<tr><th>Case</th><th>Jira Status</th><th>KB Status</th><th>Severity</th><th>Issue</th></tr>`)
+	b.WriteString(`<tr><th>Case</th><th>Severity</th><th>Issue</th></tr>`)
 	for _, row := range rows {
 		b.WriteString(`<tr><td>`)
 		b.WriteString(jiraSmartLink(row.BrowseURL, row.IssueKey, "inline"))
-		b.WriteString(`</td><td>`)
-		if row.JiraStatus != "" {
-			b.WriteString(jiraStatusMacro(row.JiraStatus))
-		} else {
-			b.WriteString(`-`)
-		}
-		b.WriteString(`</td><td>`)
-		if row.KBStatus != "" {
-			b.WriteString(triageStatusMacro(row.KBStatus))
-		} else {
-			b.WriteString(`-`)
-		}
 		b.WriteString(`</td><td>`)
 		if row.Severity != "" {
 			b.WriteString(riskStatusMacro(row.Severity))
@@ -3047,7 +3035,7 @@ func jiraOverviewSection(ei *entityIndex, jiraBaseURL string, jiraStatusByKey ma
 	}
 	b.WriteString(`</tbody></table>`)
 	if strings.TrimSpace(jiraStatusSynced) != "" {
-		b.WriteString(`<p><small>Last Jira sync: `)
+		b.WriteString(`<p><small>Last Jira reference check: `)
 		b.WriteString(escapeHTML(strings.TrimSpace(jiraStatusSynced)))
 		b.WriteString(`</small></p>`)
 	}

--- a/zap-kb/internal/output/confluence/exporter_test.go
+++ b/zap-kb/internal/output/confluence/exporter_test.go
@@ -2040,9 +2040,14 @@ func TestAppendJiraOverviewSection_RendersLinkedCases(t *testing.T) {
 	}
 	ei := buildEntityIndex(ef)
 	out := appendJiraOverviewSection("Triage Board", "<h1>Triage board</h1>", &ei, "https://example.atlassian.net/jira/software/projects/SEC", map[string]string{"SEC-42": "In Review"}, "2026-04-08T21:00:00Z")
-	for _, want := range []string{"Linked Jira Cases", "browse/SEC-42", "In Review</ac:parameter>", "TRIAGED</ac:parameter>", "HIGH</ac:parameter>", "Last Jira sync: 2026-04-08T21:00:00Z"} {
+	for _, want := range []string{"Jira References", "workflow is managed in Jira", "browse/SEC-42", "HIGH</ac:parameter>", "Last Jira reference check: 2026-04-08T21:00:00Z"} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("appendJiraOverviewSection missing %q:\n%s", want, out)
+		}
+	}
+	for _, notWant := range []string{"In Review</ac:parameter>", "TRIAGED</ac:parameter>", "<th>Jira Status</th>", "<th>KB Status</th>"} {
+		if strings.Contains(out, notWant) {
+			t.Fatalf("appendJiraOverviewSection should not render cached workflow status %q:\n%s", notWant, out)
 		}
 	}
 }

--- a/zap-kb/internal/output/jira/evidence_links.go
+++ b/zap-kb/internal/output/jira/evidence_links.go
@@ -20,10 +20,20 @@ type EvidenceLinkSummary struct {
 }
 
 func SyncFindingEvidenceLinks(ctx context.Context, ticketKeys, findingLinks map[string]string, opts Options) (EvidenceLinkSummary, error) {
+	ticketRefs := make(map[string][]string, len(ticketKeys))
+	for findingID, issueKey := range ticketKeys {
+		if strings.TrimSpace(issueKey) != "" {
+			ticketRefs[findingID] = []string{issueKey}
+		}
+	}
+	return SyncFindingEvidenceLinkRefs(ctx, ticketRefs, findingLinks, opts)
+}
+
+func SyncFindingEvidenceLinkRefs(ctx context.Context, ticketRefs map[string][]string, findingLinks map[string]string, opts Options) (EvidenceLinkSummary, error) {
 	if strings.TrimSpace(opts.BaseURL) == "" || strings.TrimSpace(opts.Username) == "" || strings.TrimSpace(opts.APIToken) == "" {
 		return EvidenceLinkSummary{}, fmt.Errorf("jira evidence link sync: missing required fields (base URL, username, api token)")
 	}
-	if len(ticketKeys) == 0 || len(findingLinks) == 0 {
+	if len(ticketRefs) == 0 || len(findingLinks) == 0 {
 		return EvidenceLinkSummary{}, nil
 	}
 
@@ -51,13 +61,23 @@ func SyncFindingEvidenceLinks(ctx context.Context, ticketKeys, findingLinks map[
 		url      string
 	}
 	var candidates []candidate
-	for findingID, issueKey := range ticketKeys {
-		issueKey = strings.TrimSpace(issueKey)
+	for findingID, refs := range ticketRefs {
 		link := strings.TrimSpace(findingLinks[findingID])
-		if issueKey == "" || link == "" {
+		if link == "" {
 			continue
 		}
-		candidates = append(candidates, candidate{issueKey: issueKey, url: link})
+		seen := map[string]struct{}{}
+		for _, ref := range refs {
+			issueKey := extractTicketKey(ref)
+			if issueKey == "" {
+				continue
+			}
+			if _, ok := seen[issueKey]; ok {
+				continue
+			}
+			seen[issueKey] = struct{}{}
+			candidates = append(candidates, candidate{issueKey: issueKey, url: link})
+		}
 	}
 	if len(candidates) == 0 {
 		return EvidenceLinkSummary{}, nil

--- a/zap-kb/internal/output/jira/evidence_links_test.go
+++ b/zap-kb/internal/output/jira/evidence_links_test.go
@@ -66,3 +66,41 @@ func TestSyncFindingEvidenceLinks_SkipsExistingRemoteLink(t *testing.T) {
 		t.Fatalf("expected no POST when link already exists, got %d", postCount)
 	}
 }
+
+func TestSyncFindingEvidenceLinkRefs_LinksAllRefsForPublishedFinding(t *testing.T) {
+	var postCount int64
+	seenGets := map[string]bool{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && (r.URL.Path == "/rest/api/3/issue/SEC-1/remotelink" || r.URL.Path == "/rest/api/3/issue/SEC-2/remotelink"):
+			seenGets[r.URL.Path] = true
+			_ = json.NewEncoder(w).Encode([]any{})
+		case r.Method == http.MethodPost && (r.URL.Path == "/rest/api/3/issue/SEC-1/remotelink" || r.URL.Path == "/rest/api/3/issue/SEC-2/remotelink"):
+			atomic.AddInt64(&postCount, 1)
+			w.WriteHeader(http.StatusCreated)
+		default:
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	sum, err := SyncFindingEvidenceLinkRefs(
+		context.Background(),
+		map[string][]string{"fin-1": {"SEC-1", "https://example.atlassian.net/browse/SEC-2", "SEC-1"}},
+		map[string]string{"fin-1": "https://example/wiki/spaces/KB/pages/123"},
+		Options{BaseURL: srv.URL, Username: "u", APIToken: "t"},
+	)
+	if err != nil {
+		t.Fatalf("SyncFindingEvidenceLinkRefs: %v", err)
+	}
+	if sum.Added != 2 || sum.Skipped != 0 || sum.Errors != 0 {
+		t.Fatalf("unexpected summary: %#v", sum)
+	}
+	if !seenGets["/rest/api/3/issue/SEC-1/remotelink"] || !seenGets["/rest/api/3/issue/SEC-2/remotelink"] {
+		t.Fatalf("expected GETs for both refs, got %#v", seenGets)
+	}
+	if atomic.LoadInt64(&postCount) != 2 {
+		t.Fatalf("expected two POSTs, got %d", postCount)
+	}
+}

--- a/zap-kb/internal/output/jira/pull.go
+++ b/zap-kb/internal/output/jira/pull.go
@@ -19,6 +19,7 @@ type PullOptions struct {
 	BaseURL  string
 	Username string
 	Token    string
+	ReadOnly bool
 }
 
 // PullResult reports what the pull operation did.
@@ -39,8 +40,10 @@ type PullStatusResult struct {
 }
 
 // PullStatus fetches the current Jira ticket status for every finding and
-// occurrence that has a TicketRef, and merges the mapped status back into
-// Analyst.Status. Jira wins on status; all other analyst fields are preserved.
+// occurrence that has a TicketRef. By default it also merges the mapped status
+// back into Analyst.Status and fills empty owners from Jira assignees. When
+// opts.ReadOnly is true it only returns RawStatuses/RawAssignees for rendering
+// and leaves the KB entity state unchanged.
 //
 // Status mapping (case-insensitive):
 //
@@ -169,7 +172,7 @@ func PullStatus(ctx context.Context, ef entities.EntitiesFile, opts PullOptions)
 		// the KB side is empty and Jira reports an assignee. This MUST run
 		// before the r.status == "" early-continue so the write-back fires
 		// even for tickets with custom/unmapped Jira workflow states.
-		if assignee := strings.TrimSpace(r.assignee); assignee != "" {
+		if assignee := strings.TrimSpace(r.assignee); assignee != "" && !opts.ReadOnly {
 			switch r.ref.kind {
 			case "finding":
 				f := &ef.Findings[r.ref.idx]
@@ -192,6 +195,10 @@ func PullStatus(ctx context.Context, ef entities.EntitiesFile, opts PullOptions)
 
 		if r.status == "" {
 			res.NotFound++
+			continue
+		}
+		if opts.ReadOnly {
+			res.Unchanged++
 			continue
 		}
 

--- a/zap-kb/internal/output/jira/pull_test.go
+++ b/zap-kb/internal/output/jira/pull_test.go
@@ -287,6 +287,50 @@ func TestPullStatus_OwnerWriteBackFillsEmptyOwner(t *testing.T) {
 	}
 }
 
+func TestPullStatus_ReadOnlyReturnsRawFieldsWithoutWriteBack(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"fields": map[string]any{
+				"status":   map[string]string{"name": "Done"},
+				"assignee": map[string]string{"displayName": "Alice Example"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	ef := makeEntities(entities.Finding{
+		FindingID: "fin-readonly",
+		Name:      "Read Only",
+		Analyst: &entities.Analyst{
+			Status:     "open",
+			Owner:      "",
+			TicketRefs: []string{"KAN-7"},
+		},
+	})
+	res, err := PullStatus(context.Background(), ef, PullOptions{
+		BaseURL:  srv.URL,
+		Username: "user",
+		Token:    "token",
+		ReadOnly: true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := res.Updated.Findings[0].Analyst.Status; got != "open" {
+		t.Errorf("status should not be written back in read-only mode; got %q", got)
+	}
+	if got := res.Updated.Findings[0].Analyst.Owner; got != "" {
+		t.Errorf("owner should not be written back in read-only mode; got %q", got)
+	}
+	if got := res.RawStatuses["KAN-7"]; got != "Done" {
+		t.Errorf("RawStatuses[KAN-7] = %q, want Done", got)
+	}
+	if got := res.RawAssignees["KAN-7"]; got != "Alice Example" {
+		t.Errorf("RawAssignees[KAN-7] = %q, want Alice Example", got)
+	}
+}
+
 func TestPullStatus_OwnerWriteBackFillsEmptyOwnerWithUnmappedStatus(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
## Summary

- make Jira status pulls read-only by default so KB analyst state is not overwritten during publish
- keep Confluence KB rollups focused on Jira references and evidence links instead of cached workflow status
- sync Jira evidence remote links for all active finding ticket refs, not only tickets created in the current run
- add Atlassian Cloud reference notes for future sessions

## Validation

- `go test ./cmd/zap-kb`
- `go test ./internal/output/jira`
- `go test ./internal/output/confluence`
- `go test ./...`
