### PR TITLE
[codex] Address KB Jira review feedback

### DIFF
--- a/zap-kb/cmd/zap-kb/jira_sync.go
+++ b/zap-kb/cmd/zap-kb/jira_sync.go
@@ -111,6 +111,10 @@ func collectFindingTicketRefs(ent entities.EntitiesFile) map[string][]string {
 	return out
 }
 
+func shouldPersistJiraEntities(addedTicketKeys, updatedEpicRefs int, jiraSyncKBStatus bool, ent entities.EntitiesFile) bool {
+	return addedTicketKeys > 0 || updatedEpicRefs > 0 || (jiraSyncKBStatus && hasFindingTicketRefs(ent))
+}
+
 func persistJiraEntities(ctx jiraSyncContext, ent entities.EntitiesFile) (string, error) {
 	switch strings.TrimSpace(ctx.Format) {
 	case "entities":

--- a/zap-kb/cmd/zap-kb/jira_sync_test.go
+++ b/zap-kb/cmd/zap-kb/jira_sync_test.go
@@ -67,6 +67,20 @@ func TestCollectFindingTicketRefs_DedupesByFinding(t *testing.T) {
 	}
 }
 
+func TestShouldPersistJiraEntities_IncludesEpicRefUpdates(t *testing.T) {
+	ent := testEntitiesFile()
+	if !shouldPersistJiraEntities(0, 1, false, ent) {
+		t.Fatal("expected definition Epic ref updates to require persistence")
+	}
+	if shouldPersistJiraEntities(0, 0, false, ent) {
+		t.Fatal("did not expect persistence with no Jira state changes")
+	}
+	ent.Findings[0].Analyst = &entities.Analyst{TicketRefs: []string{"SEC-42"}}
+	if !shouldPersistJiraEntities(0, 0, true, ent) {
+		t.Fatal("expected legacy KB status sync mode with ticket refs to require persistence")
+	}
+}
+
 func TestMergeDefinitionEpicRefs_SetsAndSkipsExisting(t *testing.T) {
 	ent := testEntitiesFile()
 	ent.Definitions = []entities.Definition{

--- a/zap-kb/cmd/zap-kb/main.go
+++ b/zap-kb/cmd/zap-kb/main.go
@@ -684,6 +684,7 @@ func main() {
 		fmt.Printf("Jira: created=%d skipped=%d errors=%d relinked=%d\n", sum.Created, sum.Skipped, sum.Errors, sum.Relinked)
 
 		addedTicketKeys := 0
+		updatedEpicRefs := 0
 		jiraStatusByKey := map[string]string(nil)
 		jiraAssigneeByKey := map[string]string(nil)
 		jiraStatusSynced := ""
@@ -692,6 +693,7 @@ func main() {
 		}
 		if !jiraDryRun && len(sum.EpicKeys) > 0 {
 			if n := mergeDefinitionEpicRefs(&ent, sum.EpicKeys); n > 0 {
+				updatedEpicRefs = n
 				fmt.Printf("Jira: recorded %d detection epic reference(s)\n", n)
 			}
 		}
@@ -714,15 +716,15 @@ func main() {
 				jiraAssigneeByKey = pullRes.RawAssignees
 				jiraStatusSynced = pullRes.SyncedAt
 				if jiraSyncKBStatus {
-					fmt.Printf("Jira pull: updated=%d unchanged=%d notfound=%d errors=%d\n",
-						pullRes.Result.Updated, pullRes.Result.Unchanged, pullRes.Result.NotFound, pullRes.Result.Errors)
+					fmt.Printf("Jira pull: updated=%d unchanged=%d notfound=%d unmapped=%d errors=%d\n",
+						pullRes.Result.Updated, pullRes.Result.Unchanged, pullRes.Result.NotFound, pullRes.Result.Unmapped, pullRes.Result.Errors)
 				} else {
-					fmt.Printf("Jira pull: fetched=%d notfound=%d errors=%d (KB status write-back disabled)\n",
-						pullRes.Result.Unchanged, pullRes.Result.NotFound, pullRes.Result.Errors)
+					fmt.Printf("Jira pull: fetched=%d notfound=%d unmapped=%d errors=%d (KB status write-back disabled)\n",
+						pullRes.Result.Unchanged+pullRes.Result.Unmapped, pullRes.Result.NotFound, pullRes.Result.Unmapped, pullRes.Result.Errors)
 				}
 			}
 		}
-		if !jiraDryRun && (addedTicketKeys > 0 || (jiraSyncKBStatus && hasFindingTicketRefs(ent))) {
+		if !jiraDryRun && shouldPersistJiraEntities(addedTicketKeys, updatedEpicRefs, jiraSyncKBStatus, ent) {
 			var artPtr *runartifact.Artifact
 			if runInIsArtifact {
 				artPtr = &runInArtifact
@@ -1134,8 +1136,8 @@ func runPullCommand(args []string) {
 			os.Exit(1)
 		}
 		ef = jRes.Updated
-		fmt.Printf("Jira pull: %d updated, %d unchanged, %d not found, %d errors\n",
-			jRes.Result.Updated, jRes.Result.Unchanged, jRes.Result.NotFound, jRes.Result.Errors)
+		fmt.Printf("Jira pull: %d updated, %d unchanged, %d not found, %d unmapped, %d errors\n",
+			jRes.Result.Updated, jRes.Result.Unchanged, jRes.Result.NotFound, jRes.Result.Unmapped, jRes.Result.Errors)
 	}
 
 	// Confluence workflow pull (optional).

--- a/zap-kb/docs/atlassian-cloud.md
+++ b/zap-kb/docs/atlassian-cloud.md
@@ -1,40 +1,41 @@
 # Atlassian Cloud References
 
-This project has published KB artifacts to Atlassian Cloud.
+This project can publish KB artifacts to Atlassian Cloud through the
+Confluence and Jira REST APIs.
 
-## Entry Points
+## Required Configuration
 
-- Atlassian site: `https://jameslerud.atlassian.net`
-- Confluence Cloud: `https://jameslerud.atlassian.net/wiki`
-- Jira issue URL pattern: `https://jameslerud.atlassian.net/browse/<KEY>`
-- Observed Jira project key: `KAN`
+- `CONFLUENCE_URL`: Confluence base URL, normally `https://<tenant>.atlassian.net/wiki`.
+- `CONFLUENCE_USER`: Atlassian account email used for Confluence API calls.
+- `CONFLUENCE_TOKEN`: Atlassian API token for Confluence API calls.
+- `CONFLUENCE_SPACE`: target Confluence space key, for example `KB2`.
+- `JIRA_URL`: Jira site URL, normally `https://<tenant>.atlassian.net`.
+- `JIRA_USER`: Atlassian account email used for Jira API calls. Falls back to `CONFLUENCE_USER` in some helper scripts.
+- `JIRA_API_TOKEN`: Atlassian API token for Jira API calls. Falls back to `CONFLUENCE_TOKEN` in some helper scripts.
+- `JIRA_PROJECT`: Jira project key used for analyst cases.
+- `JIRA_SERVER_ID`: optional Confluence application-link UUID for rendering the live Jira Issues macro.
+- `JIRA_SERVER_NAME`: optional Confluence application-link display name for rendering the live Jira Issues macro.
 
-## Confirmed Cloud Pages
+## Stable Entry Points
 
-- DevSecOps home: `https://jameslerud.atlassian.net/spaces/DEVSECOPS/overview`
-- KB index, space `KB1`: `https://jameslerud.atlassian.net/spaces/KB1/pages/2850819/KB+Index`
-- KB index, space `KB2`: `https://jameslerud.atlassian.net/spaces/KB2/pages/24117249/KB+Index`
-- Definitions, space `KB1`: `https://jameslerud.atlassian.net/spaces/KB1/pages/2785490/Definitions`
-- Security Rule Definitions, space `KB2`: `https://jameslerud.atlassian.net/spaces/KB2/pages/24412161/Security+Rule+Definitions`
-
-## Confirmed Jira Access
-
-- Atlassian API identity: `james.lerud` / `james.lerud@gmail.com`
-- Visible Jira project: `KAN: DevSecOps`
-- Recent observed issues include `KAN-203`, `KAN-204`, `KAN-208`, `KAN-209`, `KAN-210`, and epics `KAN-211`, `KAN-212`, `KAN-213`.
+- Confluence Cloud: `https://<tenant>.atlassian.net/wiki`
+- Jira issue URL pattern: `https://<tenant>.atlassian.net/browse/<KEY>`
+- KB index URL pattern: `https://<tenant>.atlassian.net/spaces/<SPACE>/pages/<PAGE_ID>/<PAGE_TITLE>`
 
 ## Local Evidence
 
-These local generated files contain references to the Atlassian Cloud tenant:
+Generated publish summaries may contain the active Atlassian tenant and project
+used for a run. Look under the configured publish output root for:
 
-- `zap-kb/docs/obsidian/findings/*.md` include analyst case links such as `KAN-189`.
-- `_ext_devsecopsfiringranve/exports/kb-publish/runs/run-20260412234358-243efbf0/publish-summary.json` records:
-  - `confluence_url`: `https://jameslerud.atlassian.net/wiki`
-  - `jira_url`: `https://jameslerud.atlassian.net`
-- `_ext_devsecopsfiringranve/scripts/publish-to-confluence-via-kb.ps1` defaults `JiraUrl` to `https://jameslerud.atlassian.net`.
+- `exports/kb-publish/runs/<run-id>/publish-summary.json`
+- `exports/kb-publish/campaigns/<campaign-id>/publish-summary.json`
+
+Generated Obsidian finding pages can also contain analyst ticket references in
+frontmatter or the `Analyst Cases` property.
 
 ## Notes For Future Sessions
 
-- Do not store API tokens, passwords, or Atlassian API keys in this file.
-- If browser login is needed, open Confluence Cloud at `https://jameslerud.atlassian.net/wiki`.
-- If looking for the published DevSecOps KB in Atlassian Cloud, start from Confluence search or the recent pages under the site above.
+- Do not store API tokens, passwords, account emails, tenant names, or private page IDs in this file.
+- Prefer environment variables or local ignored helper scripts for tenant-specific defaults.
+- For KB2 work, inspect only the configured KB2 Confluence space unless the user explicitly broadens scope.
+- Jira should remain the workflow source of truth; the KB should link to Jira cases and published evidence without mirroring live ticket status by default.

--- a/zap-kb/internal/output/jira/pull.go
+++ b/zap-kb/internal/output/jira/pull.go
@@ -27,6 +27,7 @@ type PullResult struct {
 	Updated   int
 	Unchanged int
 	NotFound  int
+	Unmapped  int
 	Errors    int
 }
 
@@ -194,7 +195,7 @@ func PullStatus(ctx context.Context, ef entities.EntitiesFile, opts PullOptions)
 		}
 
 		if r.status == "" {
-			res.NotFound++
+			res.Unmapped++
 			continue
 		}
 		if opts.ReadOnly {

--- a/zap-kb/internal/output/jira/pull_test.go
+++ b/zap-kb/internal/output/jira/pull_test.go
@@ -365,6 +365,41 @@ func TestPullStatus_OwnerWriteBackFillsEmptyOwnerWithUnmappedStatus(t *testing.T
 	if got := res.Updated.Findings[0].Analyst.Owner; got != "Alice Example" {
 		t.Errorf("expected owner='Alice Example' for unmapped status; got %q", got)
 	}
+	if res.Result.Unmapped != 1 || res.Result.NotFound != 0 {
+		t.Errorf("expected unmapped=1 notFound=0, got unmapped=%d notFound=%d", res.Result.Unmapped, res.Result.NotFound)
+	}
+}
+
+func TestPullStatus_UnmappedStatusCountsSeparatelyFromNotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(issueStatusResponse("Custom Workflow State"))
+	}))
+	defer srv.Close()
+
+	ef := makeEntities(entities.Finding{
+		FindingID: "fin-unmapped",
+		Name:      "Unmapped",
+		Analyst: &entities.Analyst{
+			Status:     "open",
+			TicketRefs: []string{"KAN-10"},
+		},
+	})
+	res, err := PullStatus(context.Background(), ef, PullOptions{
+		BaseURL:  srv.URL,
+		Username: "user",
+		Token:    "token",
+		ReadOnly: true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Result.Unmapped != 1 || res.Result.NotFound != 0 {
+		t.Fatalf("expected unmapped=1 notFound=0, got unmapped=%d notFound=%d", res.Result.Unmapped, res.Result.NotFound)
+	}
+	if got := res.RawStatuses["KAN-10"]; got != "Custom Workflow State" {
+		t.Fatalf("RawStatuses[KAN-10] = %q, want Custom Workflow State", got)
+	}
 }
 
 func TestPullStatus_OwnerWriteBackPreservesExistingOwner(t *testing.T) {


### PR DESCRIPTION
## Summary

- persist entities when Jira detection Epic refs are updated even if KB status write-back is disabled
- report unmapped Jira workflow statuses separately from missing tickets
- sanitize Atlassian reference docs and replace one-off artifact paths with stable patterns

## Validation

- `go test ./cmd/zap-kb`
- `go test ./internal/output/jira`
- `go test ./...`

## Follow-up to

- Copilot comments on #87
