### PR TITLE
[codex] Address taxonomy cache review feedback

### DIFF
--- a/zap-kb/cmd/zap-kb/taxonomy_cmd.go
+++ b/zap-kb/cmd/zap-kb/taxonomy_cmd.go
@@ -258,7 +258,7 @@ func runTaxonomyUpdate(args []string) {
 	var source string
 	var out string
 	var sourceURL string
-	fs.StringVar(&source, "source", "attack", "Source to update: attack")
+	fs.StringVar(&source, "source", "attack", "Source to update: attack|cwe|capec")
 	fs.StringVar(&out, "out", "", "Output cache JSON path")
 	fs.StringVar(&sourceURL, "url", "", "Source URL for the selected catalog")
 	if err := fs.Parse(args); err != nil {
@@ -454,7 +454,7 @@ func fetchCWECache(sourceURL string) (cweCache, error) {
 		return cweCache{}, err
 	}
 	xmlData := raw
-	if strings.HasSuffix(strings.ToLower(strings.TrimSpace(sourceURL)), ".zip") {
+	if isZipPayload(raw) {
 		xmlData, err = firstXMLFromZip(raw)
 		if err != nil {
 			return cweCache{}, err
@@ -480,7 +480,7 @@ func fetchCAPECCache(sourceURL string) (capecCache, error) {
 		return capecCache{}, err
 	}
 	xmlData := raw
-	if strings.HasSuffix(strings.ToLower(strings.TrimSpace(sourceURL)), ".zip") {
+	if isZipPayload(raw) {
 		xmlData, err = firstXMLFromZip(raw)
 		if err != nil {
 			return capecCache{}, err
@@ -521,7 +521,18 @@ func fetchURLBytes(sourceURL, accept string, limit int64) ([]byte, error) {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		return nil, fmt.Errorf("GET %s: status=%d body=%s", sourceURL, resp.StatusCode, strings.TrimSpace(string(body)))
 	}
-	return io.ReadAll(io.LimitReader(resp.Body, limit))
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, limit+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(raw)) > limit {
+		return nil, fmt.Errorf("GET %s: response exceeded size limit of %d bytes", sourceURL, limit)
+	}
+	return raw, nil
+}
+
+func isZipPayload(raw []byte) bool {
+	return len(raw) >= 2 && raw[0] == 'P' && raw[1] == 'K'
 }
 
 func firstXMLFromZip(raw []byte) ([]byte, error) {

--- a/zap-kb/cmd/zap-kb/taxonomy_cmd_test.go
+++ b/zap-kb/cmd/zap-kb/taxonomy_cmd_test.go
@@ -139,7 +139,7 @@ func TestFetchCWECacheFromZip(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	cache, err := fetchCWECache(srv.URL + "/cwe.zip")
+	cache, err := fetchCWECache(srv.URL + "/download")
 	if err != nil {
 		t.Fatalf("fetchCWECache: %v", err)
 	}
@@ -148,6 +148,33 @@ func TestFetchCWECacheFromZip(t *testing.T) {
 	}
 	if len(cache.Weaknesses) != 1 || cache.Weaknesses[0].ID != 79 {
 		t.Fatalf("bad weaknesses: %+v", cache.Weaknesses)
+	}
+}
+
+func TestIsZipPayload(t *testing.T) {
+	if !isZipPayload([]byte{'P', 'K', 0x03, 0x04, 'x'}) {
+		t.Fatal("expected ZIP magic header to be detected")
+	}
+	if !isZipPayload([]byte{'P', 'K', 0x05, 0x06}) {
+		t.Fatal("expected empty ZIP archive signature to be detected")
+	}
+	if isZipPayload([]byte("<xml></xml>")) {
+		t.Fatal("did not expect XML to be detected as ZIP")
+	}
+}
+
+func TestFetchURLBytesErrorsWhenLimitExceeded(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("123456"))
+	}))
+	defer srv.Close()
+
+	_, err := fetchURLBytes(srv.URL, "text/plain", 5)
+	if err == nil {
+		t.Fatal("expected size limit error")
+	}
+	if got := err.Error(); got != "GET "+srv.URL+": response exceeded size limit of 5 bytes" {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- detect ZIP catalog downloads by payload magic bytes instead of URL suffix
- return explicit errors when taxonomy downloads exceed the configured size cap
- update `taxonomy update -source` help text to list all supported sources

## Validation

- `go test ./cmd/zap-kb`
- `go test ./...`
- live smoke test generated temp CWE and CAPEC caches from official public sources

Follow-up to Copilot comments on #89.
