### PR TITLE
[codex] Add cache-backed MITRE enrichment

### DIFF
--- a/zap-kb/cmd/zap-kb/main.go
+++ b/zap-kb/cmd/zap-kb/main.go
@@ -50,6 +50,9 @@ func main() {
 		trafficMinRisk     string
 		includeDetect      bool
 		includeMITRE       bool
+		mitreCWECache      string
+		mitreCAPECCache    string
+		mitreATTACKCache   string
 		includeCVSS        bool
 		detectDetails      string
 		initMode           bool
@@ -123,6 +126,9 @@ func main() {
 	flag.StringVar(&zapBase, "zap-base-url", "", "Optional ZAP base URL to link back to messages in Obsidian")
 	flag.BoolVar(&includeDetect, "include-detection", false, "Enrich with detection logic links from ZAP docs/GitHub")
 	flag.BoolVar(&includeMITRE, "include-mitre", true, "Enrich taxonomy with curated MITRE CWE/CAPEC/ATT&CK metadata")
+	flag.StringVar(&mitreCWECache, "mitre-cwe-cache", "", "Optional local CWE cache JSON from `zap-kb taxonomy update -source cwe`")
+	flag.StringVar(&mitreCAPECCache, "mitre-capec-cache", "", "Optional local CAPEC cache JSON from `zap-kb taxonomy update -source capec`")
+	flag.StringVar(&mitreATTACKCache, "mitre-attack-cache", "", "Optional local ATT&CK cache JSON from `zap-kb taxonomy update -source attack`")
 	flag.BoolVar(&includeCVSS, "include-cvss", true, "Estimate definition CVSS from scanner risk when official CVSS is unavailable")
 	flag.StringVar(&detectDetails, "detection-details", "links", "Detection enrichment detail: links|summary")
 	flag.BoolVar(&initMode, "init", false, "Init KB without run data: seed/update definitions only (no alert fetch)")
@@ -548,7 +554,15 @@ func main() {
 		// Enrich taxonomy (CWE→OWASP) from static map — always runs, best-effort
 		entities.EnrichTaxonomy(ent.Definitions)
 		if includeMITRE {
-			entities.EnrichMITRE(ent.Definitions)
+			mitreCatalogs, err := entities.LoadMITRECatalogs(entities.MITRECachePaths{
+				CWE:    mitreCWECache,
+				CAPEC:  mitreCAPECCache,
+				ATTACK: mitreATTACKCache,
+			})
+			if err != nil {
+				log.Fatalf("load MITRE caches: %v", err)
+			}
+			entities.EnrichMITREWithCatalogs(ent.Definitions, mitreCatalogs)
 		}
 		if includeCVSS {
 			entities.EnrichCVSS(&ent)

--- a/zap-kb/docs/enrichment-strategy.md
+++ b/zap-kb/docs/enrichment-strategy.md
@@ -16,6 +16,9 @@ Default-on enrichments run after normalization and merge:
   scanner risk when no CVSS is already present.
 
 These can be disabled with `-include-mitre=false` or `-include-cvss=false`.
+Official catalog caches can be supplied with `-mitre-cwe-cache`,
+`-mitre-capec-cache`, and `-mitre-attack-cache`; when absent, the built-in
+curated metadata tables remain the fallback.
 
 ## CVSS Policy
 
@@ -60,6 +63,18 @@ and related weakness IDs. The CAPEC update command reads MITRE's current CAPEC
 XML and records attack pattern IDs, names, URLs, status, and related CWE IDs.
 `suggest-capec` reports candidate mappings from official CAPEC related-CWE data.
 Mapping decisions should remain explicit and testable on top of these caches.
+Runtime enrichment can consume reviewed local caches without network access:
+
+```powershell
+go run ./cmd/zap-kb -entities-in docs/data/entities.json -out docs/data/entities.enriched.json `
+  -mitre-cwe-cache docs/data/cwe-cache.json `
+  -mitre-capec-cache docs/data/capec-cache.json `
+  -mitre-attack-cache docs/data/attack-techniques.json
+```
+
+Cache-backed enrichment only expands metadata for identifiers already present
+or derived by curated mappings. It does not infer ATT&CK techniques from CWE or
+CAPEC relationships.
 
 Stored taxonomy keeps both compatibility and rich fields:
 

--- a/zap-kb/internal/entities/mitre_catalogs.go
+++ b/zap-kb/internal/entities/mitre_catalogs.go
@@ -1,0 +1,185 @@
+package entities
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+)
+
+const (
+	cweCacheSchema    = "devsecopskb/cwe-cache/v1"
+	capecCacheSchema  = "devsecopskb/capec-cache/v1"
+	attackCacheSchema = "devsecopskb/attack-technique-cache/v1"
+)
+
+// MITRECachePaths points at local JSON caches written by `zap-kb taxonomy update`.
+// Empty paths are ignored, preserving the built-in offline fallback tables.
+type MITRECachePaths struct {
+	CWE    string
+	CAPEC  string
+	ATTACK string
+}
+
+// MITRECatalogs stores local official-catalog metadata for runtime enrichment.
+// It intentionally carries only display metadata; mapping decisions still come
+// from scanner IDs or curated KB mappings.
+type MITRECatalogs struct {
+	cwe    map[int]mitreCatalogRef
+	capec  map[int]mitreCatalogRef
+	attack map[string]mitreCatalogRef
+}
+
+type mitreCatalogRef struct {
+	ID        string
+	Name      string
+	URL       string
+	Source    string
+	SourceURL string
+	Version   string
+}
+
+// LoadMITRECatalogs reads any supplied local official-catalog caches.
+func LoadMITRECatalogs(paths MITRECachePaths) (*MITRECatalogs, error) {
+	catalogs := &MITRECatalogs{}
+	if path := strings.TrimSpace(paths.CWE); path != "" {
+		refs, err := readCWECacheCatalog(path)
+		if err != nil {
+			return nil, fmt.Errorf("read CWE cache %q: %w", path, err)
+		}
+		catalogs.cwe = refs
+	}
+	if path := strings.TrimSpace(paths.CAPEC); path != "" {
+		refs, err := readCAPECCacheCatalog(path)
+		if err != nil {
+			return nil, fmt.Errorf("read CAPEC cache %q: %w", path, err)
+		}
+		catalogs.capec = refs
+	}
+	if path := strings.TrimSpace(paths.ATTACK); path != "" {
+		refs, err := readATTACKCacheCatalog(path)
+		if err != nil {
+			return nil, fmt.Errorf("read ATT&CK cache %q: %w", path, err)
+		}
+		catalogs.attack = refs
+	}
+	return catalogs, nil
+}
+
+func readCWECacheCatalog(path string) (map[int]mitreCatalogRef, error) {
+	var cache struct {
+		Schema      string `json:"schema"`
+		SourceURL   string `json:"sourceUrl"`
+		GeneratedAt string `json:"generatedAt"`
+		Version     string `json:"version"`
+		Weaknesses  []struct {
+			ID   int    `json:"id"`
+			Name string `json:"name"`
+			URL  string `json:"url"`
+		} `json:"weaknesses"`
+	}
+	if err := readCatalogJSON(path, cweCacheSchema, &cache); err != nil {
+		return nil, err
+	}
+	refs := make(map[int]mitreCatalogRef, len(cache.Weaknesses))
+	for _, item := range cache.Weaknesses {
+		if item.ID <= 0 {
+			continue
+		}
+		refs[item.ID] = mitreCatalogRef{
+			ID:        fmt.Sprintf("CWE-%d", item.ID),
+			Name:      strings.TrimSpace(item.Name),
+			URL:       strings.TrimSpace(item.URL),
+			Source:    "MITRE CWE",
+			SourceURL: firstNonEmptyString(cache.SourceURL, item.URL),
+			Version:   strings.TrimSpace(cache.Version),
+		}
+	}
+	return refs, nil
+}
+
+func readCAPECCacheCatalog(path string) (map[int]mitreCatalogRef, error) {
+	var cache struct {
+		Schema         string `json:"schema"`
+		SourceURL      string `json:"sourceUrl"`
+		GeneratedAt    string `json:"generatedAt"`
+		Version        string `json:"version"`
+		AttackPatterns []struct {
+			ID   int    `json:"id"`
+			Name string `json:"name"`
+			URL  string `json:"url"`
+		} `json:"attackPatterns"`
+	}
+	if err := readCatalogJSON(path, capecCacheSchema, &cache); err != nil {
+		return nil, err
+	}
+	refs := make(map[int]mitreCatalogRef, len(cache.AttackPatterns))
+	for _, item := range cache.AttackPatterns {
+		if item.ID <= 0 {
+			continue
+		}
+		refs[item.ID] = mitreCatalogRef{
+			ID:        fmt.Sprintf("CAPEC-%d", item.ID),
+			Name:      strings.TrimSpace(item.Name),
+			URL:       strings.TrimSpace(item.URL),
+			Source:    "MITRE CAPEC",
+			SourceURL: firstNonEmptyString(cache.SourceURL, item.URL),
+			Version:   strings.TrimSpace(cache.Version),
+		}
+	}
+	return refs, nil
+}
+
+func readATTACKCacheCatalog(path string) (map[string]mitreCatalogRef, error) {
+	var cache struct {
+		Schema      string `json:"schema"`
+		SourceURL   string `json:"sourceUrl"`
+		GeneratedAt string `json:"generatedAt"`
+		Techniques  []struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+			URL  string `json:"url"`
+		} `json:"techniques"`
+	}
+	if err := readCatalogJSON(path, attackCacheSchema, &cache); err != nil {
+		return nil, err
+	}
+	refs := make(map[string]mitreCatalogRef, len(cache.Techniques))
+	for _, item := range cache.Techniques {
+		id := strings.ToUpper(strings.TrimSpace(item.ID))
+		if id == "" {
+			continue
+		}
+		refs[id] = mitreCatalogRef{
+			ID:        id,
+			Name:      strings.TrimSpace(item.Name),
+			URL:       strings.TrimSpace(item.URL),
+			Source:    "MITRE ATT&CK",
+			SourceURL: firstNonEmptyString(cache.SourceURL, item.URL),
+			Version:   strings.TrimSpace(cache.GeneratedAt),
+		}
+	}
+	return refs, nil
+}
+
+func readCatalogJSON(path, expectedSchema string, out any) error {
+	raw, err := os.ReadFile(strings.TrimSpace(path))
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(expectedSchema) != "" {
+		var envelope struct {
+			Schema string `json:"schema"`
+		}
+		if err := json.Unmarshal(raw, &envelope); err != nil {
+			return err
+		}
+		if strings.TrimSpace(envelope.Schema) != expectedSchema {
+			return fmt.Errorf("unexpected schema %q, want %q", envelope.Schema, expectedSchema)
+		}
+	}
+	if err := json.Unmarshal(raw, out); err != nil {
+		return err
+	}
+	return nil
+}

--- a/zap-kb/internal/entities/mitre_enrich.go
+++ b/zap-kb/internal/entities/mitre_enrich.go
@@ -11,6 +11,13 @@ import (
 // MITRE-maintained titles, canonical URLs, source attribution, and mapping
 // confidence. It is offline and best-effort; it never overwrites analyst data.
 func EnrichMITRE(defs []Definition) {
+	EnrichMITREWithCatalogs(defs, nil)
+}
+
+// EnrichMITREWithCatalogs expands existing CWE, CAPEC, and ATT&CK identifiers
+// using local official-catalog caches when provided, then falls back to the
+// built-in curated metadata tables.
+func EnrichMITREWithCatalogs(defs []Definition, catalogs *MITRECatalogs) {
 	for i := range defs {
 		d := &defs[i]
 		if d.Taxonomy == nil {
@@ -19,28 +26,28 @@ func EnrichMITRE(defs []Definition) {
 		t := d.Taxonomy
 
 		if t.CWEID > 0 {
-			if ref := zapmeta.LookupCWEInfo(t.CWEID); ref != nil {
+			if ref := lookupCWERef(catalogs, t.CWEID); ref != nil {
 				if strings.TrimSpace(t.CWEName) == "" {
 					t.CWEName = ref.Name
 				}
 				if strings.TrimSpace(t.CWEURI) == "" {
 					t.CWEURI = ref.URL
 				}
-				addTaxonomySource(t, TaxonomySource{Name: ref.Source, URL: ref.URL})
+				addMITRECatalogSource(t, ref)
 			}
 		}
 
 		for _, id := range t.CAPECIDs {
-			if ref := zapmeta.LookupCAPECInfo(id); ref != nil {
+			if ref := lookupCAPECRef(catalogs, id); ref != nil {
 				upsertTaxonomyRef(&t.CAPEC, TaxonomyRef{ID: ref.ID, Name: ref.Name, URL: ref.URL})
-				addTaxonomySource(t, TaxonomySource{Name: ref.Source, URL: ref.URL})
+				addMITRECatalogSource(t, ref)
 			}
 		}
 
 		for _, id := range t.ATTACK {
-			if ref := zapmeta.LookupATTACKInfo(id); ref != nil {
+			if ref := lookupATTACKRef(catalogs, id); ref != nil {
 				upsertTaxonomyRef(&t.ATTACKTechniques, TaxonomyRef{ID: ref.ID, Name: ref.Name, URL: ref.URL})
-				addTaxonomySource(t, TaxonomySource{Name: ref.Source, URL: ref.URL})
+				addMITRECatalogSource(t, ref)
 			}
 		}
 
@@ -55,6 +62,55 @@ func EnrichMITRE(defs []Definition) {
 			}
 		}
 	}
+}
+
+func lookupCWERef(catalogs *MITRECatalogs, id int) *mitreCatalogRef {
+	if catalogs != nil && catalogs.cwe != nil {
+		if ref, ok := catalogs.cwe[id]; ok {
+			return &ref
+		}
+	}
+	return catalogRefFromZapmeta(zapmeta.LookupCWEInfo(id), "")
+}
+
+func lookupCAPECRef(catalogs *MITRECatalogs, id int) *mitreCatalogRef {
+	if catalogs != nil && catalogs.capec != nil {
+		if ref, ok := catalogs.capec[id]; ok {
+			return &ref
+		}
+	}
+	return catalogRefFromZapmeta(zapmeta.LookupCAPECInfo(id), "")
+}
+
+func lookupATTACKRef(catalogs *MITRECatalogs, id string) *mitreCatalogRef {
+	id = strings.ToUpper(strings.TrimSpace(id))
+	if catalogs != nil && catalogs.attack != nil {
+		if ref, ok := catalogs.attack[id]; ok {
+			return &ref
+		}
+	}
+	return catalogRefFromZapmeta(zapmeta.LookupATTACKInfo(id), "")
+}
+
+func catalogRefFromZapmeta(ref *zapmeta.MITRERef, version string) *mitreCatalogRef {
+	if ref == nil {
+		return nil
+	}
+	return &mitreCatalogRef{
+		ID:        ref.ID,
+		Name:      ref.Name,
+		URL:       ref.URL,
+		Source:    ref.Source,
+		SourceURL: ref.URL,
+		Version:   strings.TrimSpace(version),
+	}
+}
+
+func addMITRECatalogSource(t *Taxonomy, ref *mitreCatalogRef) {
+	if ref == nil {
+		return
+	}
+	addTaxonomySource(t, TaxonomySource{Name: ref.Source, URL: firstNonEmptyString(ref.SourceURL, ref.URL), Version: ref.Version})
 }
 
 // EnrichCVSS estimates definition-level CVSS when no official score is present.
@@ -123,9 +179,12 @@ func addTaxonomySource(t *Taxonomy, src TaxonomySource) {
 	src.Name = strings.TrimSpace(src.Name)
 	src.URL = strings.TrimSpace(src.URL)
 	src.Version = strings.TrimSpace(src.Version)
-	for _, existing := range t.Sources {
-		if strings.EqualFold(strings.TrimSpace(existing.Name), src.Name) &&
-			strings.EqualFold(strings.TrimSpace(existing.URL), src.URL) {
+	for i := range t.Sources {
+		if strings.EqualFold(strings.TrimSpace(t.Sources[i].Name), src.Name) &&
+			strings.EqualFold(strings.TrimSpace(t.Sources[i].URL), src.URL) {
+			if strings.TrimSpace(t.Sources[i].Version) == "" && src.Version != "" {
+				t.Sources[i].Version = src.Version
+			}
 			return
 		}
 	}

--- a/zap-kb/internal/entities/mitre_enrich_test.go
+++ b/zap-kb/internal/entities/mitre_enrich_test.go
@@ -1,6 +1,10 @@
 package entities
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestEnrichMITREExpandsCWEAndCAPEC(t *testing.T) {
 	defs := []Definition{
@@ -57,6 +61,112 @@ func TestEnrichMITREExpandsATTACK(t *testing.T) {
 	}
 }
 
+func TestEnrichMITREWithCatalogsUsesOfficialCacheMetadata(t *testing.T) {
+	dir := t.TempDir()
+	cwePath := filepath.Join(dir, "cwe-cache.json")
+	capecPath := filepath.Join(dir, "capec-cache.json")
+	attackPath := filepath.Join(dir, "attack-cache.json")
+	writeTestFile(t, cwePath, `{
+  "schema": "devsecopskb/cwe-cache/v1",
+  "sourceUrl": "https://cwe.mitre.org/data/xml/cwec_latest.xml.zip",
+  "version": "4.20",
+  "weaknesses": [
+    {"id": 89, "name": "Cache SQL Injection", "url": "https://cwe.mitre.org/data/definitions/89.html"}
+  ]
+}`)
+	writeTestFile(t, capecPath, `{
+  "schema": "devsecopskb/capec-cache/v1",
+  "sourceUrl": "https://capec.mitre.org/data/xml/capec_latest.xml",
+  "version": "3.9",
+  "attackPatterns": [
+    {"id": 66, "name": "Cache SQL Injection Pattern", "url": "https://capec.mitre.org/data/definitions/66.html"}
+  ]
+}`)
+	writeTestFile(t, attackPath, `{
+  "schema": "devsecopskb/attack-technique-cache/v1",
+  "generatedAt": "2026-05-05T00:00:00Z",
+  "sourceUrl": "https://raw.githubusercontent.com/mitre-attack/attack-stix-data/master/enterprise-attack/enterprise-attack.json",
+  "techniques": [
+    {"id": "T1190", "name": "Cache Exploit Public-Facing Application", "url": "https://attack.mitre.org/techniques/T1190/"}
+  ]
+}`)
+	catalogs, err := LoadMITRECatalogs(MITRECachePaths{
+		CWE:    cwePath,
+		CAPEC:  capecPath,
+		ATTACK: attackPath,
+	})
+	if err != nil {
+		t.Fatalf("LoadMITRECatalogs: %v", err)
+	}
+	defs := []Definition{
+		{
+			DefinitionID: "def-sql",
+			Taxonomy: &Taxonomy{
+				CWEID:    89,
+				CAPECIDs: []int{66},
+				ATTACK:   []string{"T1190"},
+			},
+		},
+	}
+
+	EnrichMITREWithCatalogs(defs, catalogs)
+
+	tax := defs[0].Taxonomy
+	if tax.CWEName != "Cache SQL Injection" {
+		t.Fatalf("CWEName = %q", tax.CWEName)
+	}
+	if len(tax.CAPEC) != 1 || tax.CAPEC[0].Name != "Cache SQL Injection Pattern" {
+		t.Fatalf("CAPEC refs = %+v", tax.CAPEC)
+	}
+	if len(tax.ATTACKTechniques) != 1 || tax.ATTACKTechniques[0].Name != "Cache Exploit Public-Facing Application" {
+		t.Fatalf("ATTACKTechniques = %+v", tax.ATTACKTechniques)
+	}
+	if !hasTaxonomySourceVersion(tax.Sources, "MITRE CWE", "4.20") {
+		t.Fatalf("sources missing MITRE CWE version: %+v", tax.Sources)
+	}
+	if !hasTaxonomySourceVersion(tax.Sources, "MITRE CAPEC", "3.9") {
+		t.Fatalf("sources missing MITRE CAPEC version: %+v", tax.Sources)
+	}
+	if !hasTaxonomySourceVersion(tax.Sources, "MITRE ATT&CK", "2026-05-05T00:00:00Z") {
+		t.Fatalf("sources missing MITRE ATT&CK cache timestamp: %+v", tax.Sources)
+	}
+}
+
+func TestLoadMITRECatalogsRejectsWrongSchema(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "wrong-cache.json")
+	writeTestFile(t, path, `{
+  "schema": "devsecopskb/capec-cache/v1",
+  "attackPatterns": []
+}`)
+
+	_, err := LoadMITRECatalogs(MITRECachePaths{CWE: path})
+	if err == nil {
+		t.Fatal("expected wrong cache schema to fail")
+	}
+}
+
+func TestAddTaxonomySourceUpgradesMissingVersion(t *testing.T) {
+	tax := &Taxonomy{
+		Sources: []TaxonomySource{{
+			Name: "MITRE CWE",
+			URL:  "https://cwe.mitre.org/data/xml/cwec_latest.xml.zip",
+		}},
+	}
+
+	addTaxonomySource(tax, TaxonomySource{
+		Name:    "MITRE CWE",
+		URL:     "https://cwe.mitre.org/data/xml/cwec_latest.xml.zip",
+		Version: "4.20",
+	})
+
+	if len(tax.Sources) != 1 {
+		t.Fatalf("sources = %+v, want one deduplicated source", tax.Sources)
+	}
+	if tax.Sources[0].Version != "4.20" {
+		t.Fatalf("source version = %q, want 4.20", tax.Sources[0].Version)
+	}
+}
+
 func TestEnrichMITREDoesNotOverwriteAnalystFields(t *testing.T) {
 	defs := []Definition{
 		{
@@ -77,6 +187,22 @@ func TestEnrichMITREDoesNotOverwriteAnalystFields(t *testing.T) {
 	if defs[0].Taxonomy.MappingConfidence != "analyst-reviewed" {
 		t.Fatalf("MappingConfidence was overwritten: %q", defs[0].Taxonomy.MappingConfidence)
 	}
+}
+
+func writeTestFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func hasTaxonomySourceVersion(sources []TaxonomySource, name, version string) bool {
+	for _, source := range sources {
+		if source.Name == name && source.Version == version {
+			return true
+		}
+	}
+	return false
 }
 
 func TestEnrichCVSSEstimatesFromMaxDefinitionRisk(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds runtime support for local MITRE taxonomy caches generated by `zap-kb taxonomy update`.

## Changes

- Adds `entities.LoadMITRECatalogs` for local CWE, CAPEC, and ATT&CK cache JSON.
- Adds `EnrichMITREWithCatalogs`, which prefers cache metadata and falls back to the existing curated static tables.
- Wires optional CLI flags: `-mitre-cwe-cache`, `-mitre-capec-cache`, and `-mitre-attack-cache`.
- Documents the offline cache-backed enrichment workflow.
- Adds tests proving cache metadata populates CWE/CAPEC/ATT&CK rich refs and source versions.

## Policy

The new path only expands identifiers that already exist or are derived through curated mappings. It does not infer ATT&CK techniques from CWE or CAPEC relationships.

## Validation

- `go test ./internal/entities`
- `go test ./cmd/zap-kb`
- `go test ./...`
- CLI smoke test with local cache JSON files and a purpose-built entities fixture

Refs #52
