### PR TITLE
fix(taxonomy): respect KB format for custom rules; correct flagged mappings

### DIFF
--- a/zap-kb/cmd/zap-kb/main.go
+++ b/zap-kb/cmd/zap-kb/main.go
@@ -581,6 +581,15 @@ func main() {
 			}
 		}
 
+		// Apply curated taxonomy overrides for custom/internal plugin IDs first so
+		// they pre-empt the generic CWE→OWASP derivation below — always runs.
+		// Custom rules without a curated mapping are blanked (not given the
+		// scanner's placeholder CWE); surface them so they can be curated.
+		entities.EnrichCustomTaxonomy(ent.Definitions)
+		if unmapped := entities.UnmappedCustomRules(ent.Definitions); len(unmapped) > 0 {
+			fmt.Printf("Custom rules with no curated taxonomy (left blank — add to customTaxonomyMap): %s\n",
+				strings.Join(unmapped, ", "))
+		}
 		// Enrich taxonomy (CWE→OWASP) from static map — always runs, best-effort
 		entities.EnrichTaxonomy(ent.Definitions)
 		if includeMITRE {

--- a/zap-kb/internal/entities/enrich.go
+++ b/zap-kb/internal/entities/enrich.go
@@ -560,33 +560,112 @@ func EnrichDetectionSummaries(ctx context.Context, ef *EntitiesFile) {
 
 // EnrichCustomTaxonomy applies static taxonomy overrides and false positive guidance
 // for custom/internal plugin IDs (e.g., authenticated-* rules) and well-known plugin IDs
-// that have FP guidance (e.g., CDM, CSP, CDJSF). Best-effort; never overwrites existing values.
+// that have FP guidance (e.g., CDM, CSP, CDJSF). Best-effort.
+//
+// For these KB-owned custom rules the curated CWE and OWASP are authoritative:
+// when the entry specifies them they override any scanner-supplied value, so an
+// IDOR finding the scanner mislabeled CWE-200 becomes CWE-639/A01 and stays
+// consistent even on a JSON round-trip. CAPEC is likewise authoritative;
+// ATT&CK remains additive so scanner-provided identifiers are preserved.
+//
+// Custom rules are KB-owned, so the scanner's CWE is treated as an untrusted
+// placeholder: a custom rule with NO curated mapping has its taxonomy blanked
+// (rendering "Taxonomy incomplete") rather than publishing the scanner's generic
+// CWE. Standard tool plugins (numeric ZAP ids) are never blanked — their scanner
+// CWE is authoritative. UnmappedCustomRules reports the gaps for curation.
+// isCustomRule reports whether a plugin ID denotes a KB-authored custom rule (a
+// named slug such as "nuclei-auth-complaints-exposure") rather than a standard
+// tool plugin (a numeric ZAP id like "zap-10098"). It keys off the CANONICAL id
+// so the source/"custom-" prefixes are irrelevant — a tool plugin canonicalizes
+// to a number, a custom rule to a slug. This is deliberately independent of the
+// origin field, which is normalized later in the pipeline than enrichment runs.
+func isCustomRule(pluginID string) bool {
+	pid := strings.TrimSpace(pluginID)
+	if pid == "" {
+		return false
+	}
+	return !isNumericPluginID(zapmeta.CanonicalPluginID(pid))
+}
+
+// UnmappedCustomRules returns the distinct, sorted plugin IDs of custom
+// (KB-owned) definitions that have no curated taxonomy entry. These are the
+// rules whose taxonomy EnrichCustomTaxonomy blanks; the export surfaces them so
+// a maintainer knows exactly what to add to the curated map.
+func UnmappedCustomRules(defs []Definition) []string {
+	seen := map[string]struct{}{}
+	var out []string
+	for i := range defs {
+		d := &defs[i]
+		if !isCustomRule(d.PluginID) {
+			continue
+		}
+		if zapmeta.LookupCustomTaxonomy(d.PluginID) != nil {
+			continue
+		}
+		pid := strings.TrimSpace(d.PluginID)
+		if pid == "" {
+			continue
+		}
+		if _, ok := seen[pid]; ok {
+			continue
+		}
+		seen[pid] = struct{}{}
+		out = append(out, pid)
+	}
+	sort.Strings(out)
+	return out
+}
+
 func EnrichCustomTaxonomy(defs []Definition) {
 	for i := range defs {
 		d := &defs[i]
 
+		ct := zapmeta.LookupCustomTaxonomy(d.PluginID)
+		if ct == nil {
+			// No curated mapping. For a custom (KB-owned) rule, discard the
+			// scanner's placeholder taxonomy so the gap is visible instead of
+			// misleading. Tool plugins keep their scanner taxonomy.
+			if isCustomRule(d.PluginID) && d.Taxonomy != nil {
+				d.Taxonomy.CWEID = 0
+				d.Taxonomy.CWEURI = ""
+				d.Taxonomy.CWEName = ""
+				d.Taxonomy.OWASPTop10 = nil
+				d.Taxonomy.CAPECIDs = nil
+				d.Taxonomy.CAPEC = nil
+				d.Taxonomy.MappingConfidence = ""
+			}
+		}
+
 		// Apply custom taxonomy for authenticated-* and other internal rules.
-		if ct := zapmeta.LookupCustomTaxonomy(d.PluginID); ct != nil {
+		if ct != nil {
 			if d.Taxonomy == nil {
 				d.Taxonomy = &Taxonomy{}
 			}
-			if d.Taxonomy.CWEID == 0 {
+			// CWE is authoritative when the curated entry specifies one.
+			if ct.CWEID > 0 {
 				d.Taxonomy.CWEID = ct.CWEID
-			}
-			if d.Taxonomy.CWEURI == "" {
 				d.Taxonomy.CWEURI = ct.CWEURI
 			}
-			if len(d.Taxonomy.CAPECIDs) == 0 {
+			// CAPEC is authoritative when the curated entry specifies one: replace
+			// the IDs and clear any stale resolved refs so EnrichMITRE rebuilds
+			// them. This heals a JSON round-trip where the old (wrong) CWE had
+			// derived a mismatched CAPEC (e.g. CWE-200→CAPEC-118 on an IDOR
+			// finding now corrected to CWE-639). When the entry has no CAPEC we
+			// leave the scanner-provided one untouched.
+			if len(ct.CAPECIDs) > 0 {
 				ids := make([]int, len(ct.CAPECIDs))
 				copy(ids, ct.CAPECIDs)
 				d.Taxonomy.CAPECIDs = ids
+				d.Taxonomy.CAPEC = nil
 			}
 			if len(d.Taxonomy.ATTACK) == 0 {
 				atk := make([]string, len(ct.ATTACK))
 				copy(atk, ct.ATTACK)
 				d.Taxonomy.ATTACK = atk
 			}
-			if len(d.Taxonomy.OWASPTop10) == 0 {
+			// OWASP is authoritative: a curated category overrides any
+			// scanner-derived value so KB corrections take effect.
+			if len(ct.OWASPTop10) > 0 {
 				owasp := make([]string, len(ct.OWASPTop10))
 				copy(owasp, ct.OWASPTop10)
 				d.Taxonomy.OWASPTop10 = owasp

--- a/zap-kb/internal/entities/entities.go
+++ b/zap-kb/internal/entities/entities.go
@@ -332,6 +332,10 @@ func DefinitionOriginValue(origin, pluginID string, det *Detection) string {
 
 func isProjectSpecificPluginID(pluginID string) bool {
 	id := strings.ToLower(strings.TrimSpace(pluginID))
+	// The pipeline tags KB-authored rules with an explicit "custom-" marker.
+	if strings.HasPrefix(id, "custom-") {
+		return true
+	}
 	if !strings.HasPrefix(id, "zap-") {
 		return false
 	}

--- a/zap-kb/internal/entities/taxonomy.go
+++ b/zap-kb/internal/entities/taxonomy.go
@@ -8,21 +8,23 @@ import (
 )
 
 // cweToOWASP maps CWE IDs to OWASP Top 10 2021 categories.
-// CWE-264 is a deprecated umbrella; CWE-942 is the correct mapping for permissive CORS.
-// CWE-264 is retained as a backwards-compat alias.
+// CWE-264 (Permissions, Privileges, and Access Controls) is a deprecated pillar
+// and is intentionally absent here; deprecatedCWE remaps it to its canonical
+// replacement before any OWASP/CAPEC derivation runs.
 var cweToOWASP = map[int]string{
 	22:  "A01:2021",
 	79:  "A03:2021",
 	89:  "A03:2021",
 	200: "A05:2021",
 	209: "A05:2021",
-	264: "A05:2021", // deprecated alias for CWE-942 (Permissive Cross-domain Policy)
 	287: "A07:2021",
 	311: "A02:2021",
 	312: "A02:2021",
 	319: "A02:2021",
 	327: "A02:2021",
 	502: "A08:2021",
+	522: "A02:2021", // Insufficiently Protected Credentials → Cryptographic Failures
+	552: "A01:2021", // Files or Directories Accessible to External Parties → Broken Access Control
 	639: "A01:2021",
 	693: "A05:2021",
 	918: "A10:2021",
@@ -31,15 +33,31 @@ var cweToOWASP = map[int]string{
 
 // cweToCAPEC maps CWE IDs to CAPEC identifiers.
 // Static map; covers the most common ZAP finding types.
+// Note: CWE-264 is deprecated and is remapped to its canonical CWE (see
+// deprecatedCWE) before derivation, so it has no entry here.
 var cweToCAPEC = map[int]string{
 	79:  "CAPEC-86",  // XSS → Exploitation of Improper Data Validation
 	89:  "CAPEC-66",  // SQL Injection
 	200: "CAPEC-118", // Exposure of Sensitive Information
-	264: "CAPEC-122", // deprecated CDM alias (Privilege Abuse)
 	311: "CAPEC-37",  // Cleartext Storage
-	639: "CAPEC-122", // IDOR / Authorization Through User-Controlled Key
-	693: "CAPEC-1",   // Protection Mechanism Failure (CSP) → Accessing/Intercepting/Modifying HTTP Communication
-	942: "CAPEC-1",   // Permissive CORS
+	639: "CAPEC-122", // IDOR / Authorization Through User-Controlled Key → Privilege Abuse
+	693: "CAPEC-63",  // Protection Mechanism Failure (CSP/XSS defenses) → Cross-Site Scripting (the attack the missing control fails to stop)
+	942: "CAPEC-1",   // Permissive CORS → Accessing Functionality Not Properly Constrained by ACLs
+}
+
+// deprecatedCWE maps deprecated CWE identifiers to their canonical replacement.
+// Deprecated pillars carry no usable OWASP/CAPEC mapping and render poorly for
+// analysts, so they are rewritten during enrichment when a non-deprecated
+// replacement is known for the finding.
+var deprecatedCWE = map[int]int{
+	264: 942, // Permissions, Privileges, and Access Controls (deprecated) → Permissive Cross-domain Policy
+}
+
+// isDeprecatedCWE reports whether a CWE ID is a deprecated identifier that should
+// be remapped to its canonical replacement.
+func isDeprecatedCWE(cweID int) bool {
+	_, ok := deprecatedCWE[cweID]
+	return ok
 }
 
 // CWEToOWASP returns the OWASP Top 10 2021 category for a CWE ID, or "" if not mapped.
@@ -95,6 +113,21 @@ func EnrichTaxonomy(defs []Definition) {
 
 		if d.Taxonomy == nil || d.Taxonomy.CWEID == 0 {
 			continue
+		}
+
+		// Rewrite a deprecated CWE pillar to the plugin's known canonical CWE.
+		// We only remap when the plugin has a specific, non-deprecated CWE in the
+		// static catalog — a blanket deprecated→canonical map would mislabel a
+		// genuinely access-control CWE-264 finding as CORS. Any OWASP/CAPEC
+		// derived from the deprecated ID is discarded so it re-derives below.
+		if isDeprecatedCWE(d.Taxonomy.CWEID) {
+			if r := zapmeta.LookupPlugin(d.PluginID); r != nil && r.CWEID > 0 && !isDeprecatedCWE(r.CWEID) {
+				d.Taxonomy.CWEID = r.CWEID
+				d.Taxonomy.CWEURI = r.CWEURI
+				d.Taxonomy.CWEName = ""
+				d.Taxonomy.OWASPTop10 = nil
+				d.Taxonomy.CAPECIDs = nil
+			}
 		}
 
 		// If we have a CWE ID but no OWASP category, derive it.

--- a/zap-kb/internal/entities/taxonomy_test.go
+++ b/zap-kb/internal/entities/taxonomy_test.go
@@ -132,22 +132,270 @@ func TestEnrichTaxonomy_PopulatesCAPEC(t *testing.T) {
 	}
 }
 
-func TestEnrichCustomTaxonomy_AuthenticatedRule_GetsIDOR(t *testing.T) {
+func TestEnrichTaxonomy_RemapsDeprecatedCWE264(t *testing.T) {
+	// Plugin 10098 (Cross-Domain Misconfiguration) historically reports the
+	// deprecated CWE-264 with the ill-fitting CAPEC-122. Enrichment must rewrite
+	// it to the canonical CWE-942 and re-derive A05:2021 + CAPEC-1.
 	defs := []Definition{
 		{
-			DefinitionID: "def-auth-basket",
-			PluginID:     "zap-authenticated-basket-item-enumeration",
+			DefinitionID: "def-10098",
+			PluginID:     "10098",
+			Taxonomy: &Taxonomy{
+				CWEID:      264,
+				OWASPTop10: []string{"A05:2021"},
+				CAPECIDs:   []int{122},
+			},
+		},
+	}
+	EnrichTaxonomy(defs)
+	d := defs[0]
+	if d.Taxonomy.CWEID != 942 {
+		t.Errorf("CWEID = %d, want 942 (canonical replacement for deprecated 264)", d.Taxonomy.CWEID)
+	}
+	if len(d.Taxonomy.OWASPTop10) != 1 || d.Taxonomy.OWASPTop10[0] != "A05:2021" {
+		t.Errorf("OWASPTop10 = %v, want [A05:2021]", d.Taxonomy.OWASPTop10)
+	}
+	if len(d.Taxonomy.CAPECIDs) != 1 || d.Taxonomy.CAPECIDs[0] != 1 {
+		t.Errorf("CAPECIDs = %v, want [1] (CAPEC-1, not the deprecated CAPEC-122)", d.Taxonomy.CAPECIDs)
+	}
+	if d.Taxonomy.CWEURI != "https://cwe.mitre.org/data/definitions/942.html" {
+		t.Errorf("CWEURI = %q, want canonical 942 URI", d.Taxonomy.CWEURI)
+	}
+}
+
+func TestCWEToCAPEC_DeprecatedPillarDropped(t *testing.T) {
+	// CWE-264 is deprecated and must not derive a CAPEC; it is remapped instead.
+	if got := CWEToCAPEC(264); got != "" {
+		t.Errorf("CWEToCAPEC(264) = %q, want empty (deprecated, remapped to 942)", got)
+	}
+	if got := CWEToOWASP(264); got != "" {
+		t.Errorf("CWEToOWASP(264) = %q, want empty (deprecated, remapped to 942)", got)
+	}
+}
+
+func TestEnrichCustomTaxonomy_HSTSAndReferrerGetTaxonomy(t *testing.T) {
+	defs := []Definition{
+		{DefinitionID: "def-hsts", PluginID: "nuclei-missing-hsts-header"},
+		{DefinitionID: "def-referrer", PluginID: "zap-missing-referrer-policy"},
+	}
+	EnrichCustomTaxonomy(defs)
+	if defs[0].Taxonomy == nil || defs[0].Taxonomy.CWEID != 319 ||
+		len(defs[0].Taxonomy.OWASPTop10) == 0 || defs[0].Taxonomy.OWASPTop10[0] != "A02:2021" {
+		t.Errorf("HSTS taxonomy = %+v, want CWE-319 / A02:2021", defs[0].Taxonomy)
+	}
+	if defs[1].Taxonomy == nil || defs[1].Taxonomy.CWEID != 200 ||
+		len(defs[1].Taxonomy.OWASPTop10) == 0 || defs[1].Taxonomy.OWASPTop10[0] != "A05:2021" {
+		t.Errorf("Referrer taxonomy = %+v, want CWE-200 / A05:2021", defs[1].Taxonomy)
+	}
+}
+
+func TestEnrichCustomTaxonomy_JWTOWASPOverridesScannerA05(t *testing.T) {
+	// The JWT password-hash finding is a cryptographic failure (A02:2021); the
+	// curated OWASP must override a scanner-supplied A05:2021.
+	defs := []Definition{
+		{
+			DefinitionID: "def-jwt",
+			PluginID:     "zap-jwt-password-hash-disclosure",
+			Taxonomy:     &Taxonomy{CWEID: 522, OWASPTop10: []string{"A05:2021"}},
 		},
 	}
 	EnrichCustomTaxonomy(defs)
 	d := defs[0]
-	if d.Taxonomy == nil {
-		t.Fatal("expected Taxonomy to be set after EnrichCustomTaxonomy")
+	if len(d.Taxonomy.OWASPTop10) != 1 || d.Taxonomy.OWASPTop10[0] != "A02:2021" {
+		t.Errorf("OWASPTop10 = %v, want [A02:2021]", d.Taxonomy.OWASPTop10)
 	}
+	// Curated CWE-522 is authoritative and overrides the scanner's CWE-200.
+	if d.Taxonomy.CWEID != 522 {
+		t.Errorf("CWEID = %d, want 522 (curated, overrides scanner CWE-200)", d.Taxonomy.CWEID)
+	}
+}
+
+func TestEnrichCustomTaxonomy_CuratedCWEOverridesScanner_IDOR(t *testing.T) {
+	// An IDOR finding the scanner mislabeled CWE-200/A05 must become the curated
+	// CWE-639/A01 (the round-trip consistency case), using a real prefixed ID.
+	// Stale CAPEC-118 + resolved ref simulate a JSON round-trip of the old
+	// (wrong) CWE-200 derivation; both must be replaced by the curated CAPEC-122.
+	defs := []Definition{{
+		DefinitionID: "def-complaints",
+		PluginID:     "nuclei-auth-complaints-exposure",
+		Taxonomy: &Taxonomy{
+			CWEID:      200,
+			OWASPTop10: []string{"A05:2021"},
+			CAPECIDs:   []int{118},
+			CAPEC:      []TaxonomyRef{{ID: "CAPEC-118", Name: "Data Leakage Attacks"}},
+		},
+	}}
+	EnrichCustomTaxonomy(defs)
+	d := defs[0]
 	if d.Taxonomy.CWEID != 639 {
-		t.Errorf("CWEID = %d, want 639", d.Taxonomy.CWEID)
+		t.Errorf("CWEID = %d, want 639 (curated overrides scanner 200)", d.Taxonomy.CWEID)
 	}
-	if len(d.Taxonomy.OWASPTop10) == 0 || d.Taxonomy.OWASPTop10[0] != "A01:2021-Broken Access Control" {
+	if len(d.Taxonomy.OWASPTop10) != 1 || d.Taxonomy.OWASPTop10[0] != "A01:2021-Broken Access Control" {
 		t.Errorf("OWASPTop10 = %v, want [A01:2021-Broken Access Control]", d.Taxonomy.OWASPTop10)
+	}
+	if len(d.Taxonomy.CAPECIDs) != 1 || d.Taxonomy.CAPECIDs[0] != 122 {
+		t.Errorf("CAPECIDs = %v, want [122] (curated replaces stale 118)", d.Taxonomy.CAPECIDs)
+	}
+	if len(d.Taxonomy.CAPEC) != 0 {
+		t.Errorf("CAPEC refs = %+v, want cleared so EnrichMITRE rebuilds them", d.Taxonomy.CAPEC)
+	}
+}
+
+func TestEnrichCustomTaxonomy_BlanksUnmappedCustomRule(t *testing.T) {
+	// A custom rule with no curated mapping must have the scanner's placeholder
+	// CWE blanked (→ "Taxonomy incomplete"), not published.
+	defs := []Definition{{
+		DefinitionID: "def-new",
+		PluginID:     "custom-nuclei-some-brand-new-rule",
+		Taxonomy:     &Taxonomy{CWEID: 200, CWEURI: "x", OWASPTop10: []string{"A05:2021"}, CAPECIDs: []int{118}},
+	}}
+	EnrichCustomTaxonomy(defs)
+	tx := defs[0].Taxonomy
+	if tx.CWEID != 0 || len(tx.OWASPTop10) != 0 || len(tx.CAPECIDs) != 0 {
+		t.Errorf("unmapped custom taxonomy not blanked: %+v", tx)
+	}
+}
+
+func TestEnrichCustomTaxonomy_DoesNotBlankToolPlugin(t *testing.T) {
+	// A standard numeric ZAP plugin is a trusted tool plugin: its scanner CWE
+	// must be preserved even though it is not in customTaxonomyMap.
+	defs := []Definition{{
+		DefinitionID: "def-tool",
+		PluginID:     "zap-10096", // Timestamp Disclosure, not a custom rule
+		Taxonomy:     &Taxonomy{CWEID: 200, OWASPTop10: []string{"A05:2021"}},
+	}}
+	EnrichCustomTaxonomy(defs)
+	if defs[0].Taxonomy.CWEID != 200 {
+		t.Errorf("tool plugin taxonomy was blanked: %+v", defs[0].Taxonomy)
+	}
+}
+
+func TestUnmappedCustomRules(t *testing.T) {
+	defs := []Definition{
+		{DefinitionID: "d1", PluginID: "nuclei-auth-complaints-exposure"}, // mapped
+		{DefinitionID: "d2", PluginID: "zap-10098"},                       // tool, ignored
+		{DefinitionID: "d3", PluginID: "custom-nuclei-brand-new-rule"},    // unmapped custom
+		{DefinitionID: "d4", PluginID: "nuclei-brand-new-rule"},           // same canonical → deduped
+	}
+	got := UnmappedCustomRules(defs)
+	if len(got) != 2 {
+		t.Fatalf("UnmappedCustomRules = %v, want the two brand-new-rule ids", got)
+	}
+}
+
+func TestEnrichCustomTaxonomy_CuratedCoversLiveCustomRules(t *testing.T) {
+	// Every custom rule visible in the live KB must resolve to curated taxonomy
+	// (no regressions to "incomplete"), using real source-prefixed IDs.
+	cases := []struct {
+		pid   string
+		cwe   int
+		owasp string
+	}{
+		{"nuclei-wildcard-cors-origin", 942, "A05:2021"},
+		{"zap-missing-csp", 693, "A05:2021"},
+		{"zap-sql-error-based-injection", 89, "A03:2021"},
+		{"nuclei-public-application-configuration", 200, "A05:2021"},
+		{"zap-stacktrace-disclosure", 209, "A05:2021"},
+		{"nuclei-legacy-ftp-surface", 552, "A01:2021-Broken Access Control"},
+	}
+	for _, c := range cases {
+		defs := []Definition{{DefinitionID: "d", PluginID: c.pid}}
+		EnrichCustomTaxonomy(defs)
+		tx := defs[0].Taxonomy
+		if tx == nil || tx.CWEID != c.cwe || len(tx.OWASPTop10) == 0 || tx.OWASPTop10[0] != c.owasp {
+			t.Errorf("%s → %+v, want CWE-%d / %s", c.pid, tx, c.cwe, c.owasp)
+		}
+	}
+}
+
+func TestCWEToCAPEC_CSPMapsToXSS(t *testing.T) {
+	// CWE-693 (protection mechanism failure / missing CSP) should map to the XSS
+	// attack pattern, not the ACL-bypass CAPEC-1.
+	if got := CWEToCAPEC(693); got != "CAPEC-63" {
+		t.Errorf("CWEToCAPEC(693) = %q, want CAPEC-63 (XSS)", got)
+	}
+}
+
+// TestPublishPipeline_FlaggedFindings exercises the full enrichment order used
+// by the export/publish path (custom → taxonomy → MITRE) over the four findings
+// the SME flagged, asserting the final taxonomy that sinks render.
+func TestPublishPipeline_FlaggedFindings(t *testing.T) {
+	defs := []Definition{
+		// CDM/CORS arriving with deprecated CWE-264 + ill-fitting CAPEC-122.
+		// Real published pluginId is source-prefixed ("zap-10098"), which misses
+		// the numeric cweFallback and exercises the static deprecation fallback.
+		{DefinitionID: "def-10098", PluginID: "zap-10098", Alert: "Cross-Domain Misconfiguration",
+			Taxonomy: &Taxonomy{CWEID: 264, OWASPTop10: []string{"A05:2021"}, CAPECIDs: []int{122}}},
+		// FTP surface arriving with CWE-552 but no resolvable name.
+		{DefinitionID: "def-ftp", PluginID: "nuclei-legacy-ftp-surface", Alert: "Legacy FTP Surface Exposed Over Web",
+			Taxonomy: &Taxonomy{CWEID: 552}},
+		// JWT password-hash arriving with the scanner's generic CWE-200 / A05.
+		{DefinitionID: "def-jwt", PluginID: "zap-jwt-password-hash-disclosure", Alert: "JWT Token Contains Password Hash",
+			Taxonomy: &Taxonomy{CWEID: 200, OWASPTop10: []string{"A05:2021"}}},
+		// Custom header rules arriving with no taxonomy at all.
+		{DefinitionID: "def-hsts", PluginID: "nuclei-missing-hsts-header", Alert: "Missing HSTS Header"},
+		{DefinitionID: "def-ref", PluginID: "nuclei-missing-referrer-policy", Alert: "Missing Referrer-Policy Header"},
+	}
+
+	// Mirror the cmd/zap-kb export order.
+	EnrichCustomTaxonomy(defs)
+	EnrichTaxonomy(defs)
+	EnrichMITRE(defs)
+
+	byID := map[string]*Definition{}
+	for i := range defs {
+		byID[defs[i].DefinitionID] = &defs[i]
+	}
+
+	// 1. CDM: deprecated 264 rewritten to 942 → A05 + CAPEC-1, named.
+	cdm := byID["def-10098"].Taxonomy
+	if cdm.CWEID != 942 || cdm.CWEName != "Permissive Cross-domain Policy with Untrusted Domains" {
+		t.Errorf("CDM CWE = %d %q, want 942 with resolved name", cdm.CWEID, cdm.CWEName)
+	}
+	if len(cdm.CAPECIDs) != 1 || cdm.CAPECIDs[0] != 1 {
+		t.Errorf("CDM CAPEC = %v, want [1]", cdm.CAPECIDs)
+	}
+	if len(cdm.OWASPTop10) != 1 || cdm.OWASPTop10[0] != "A05:2021" {
+		t.Errorf("CDM OWASP = %v, want [A05:2021]", cdm.OWASPTop10)
+	}
+
+	// 2. FTP: CWE-552 resolves to a real title (no "CWE-552: CWE-552").
+	if n := byID["def-ftp"].Taxonomy.CWEName; n != "Files or Directories Accessible to External Parties" {
+		t.Errorf("FTP CWEName = %q, want resolved title", n)
+	}
+
+	// 3. JWT: scanner CWE-200/A05 corrected to curated CWE-522/A02.
+	if jwt := byID["def-jwt"].Taxonomy; jwt.CWEID != 522 || len(jwt.OWASPTop10) != 1 || jwt.OWASPTop10[0] != "A02:2021" {
+		t.Errorf("JWT taxonomy = %+v, want CWE-522 / A02:2021", byID["def-jwt"].Taxonomy)
+	}
+
+	// 4. HSTS + Referrer: taxonomy now populated.
+	if h := byID["def-hsts"].Taxonomy; h == nil || h.CWEID != 319 || len(h.OWASPTop10) == 0 || h.OWASPTop10[0] != "A02:2021" {
+		t.Errorf("HSTS taxonomy = %+v, want CWE-319 / A02:2021", byID["def-hsts"].Taxonomy)
+	}
+	if r := byID["def-ref"].Taxonomy; r == nil || r.CWEID != 200 || len(r.OWASPTop10) == 0 || r.OWASPTop10[0] != "A05:2021" {
+		t.Errorf("Referrer taxonomy = %+v, want CWE-200 / A05:2021", byID["def-ref"].Taxonomy)
+	}
+}
+
+func TestEnrichCustomTaxonomy_AuthenticatedRule_GetsIDOR(t *testing.T) {
+	// Real pipeline IDs are source-prefixed ("zap-"/"nuclei-"); both must resolve
+	// to the same canonical IDOR taxonomy.
+	for _, pid := range []string{
+		"zap-auth-basket-items-enumeration",
+		"nuclei-auth-basket-items-enumeration",
+	} {
+		defs := []Definition{{DefinitionID: "def-auth-basket", PluginID: pid}}
+		EnrichCustomTaxonomy(defs)
+		d := defs[0]
+		if d.Taxonomy == nil {
+			t.Fatalf("%s: expected Taxonomy to be set after EnrichCustomTaxonomy", pid)
+		}
+		if d.Taxonomy.CWEID != 639 {
+			t.Errorf("%s: CWEID = %d, want 639", pid, d.Taxonomy.CWEID)
+		}
+		if len(d.Taxonomy.OWASPTop10) == 0 || d.Taxonomy.OWASPTop10[0] != "A01:2021-Broken Access Control" {
+			t.Errorf("%s: OWASPTop10 = %v, want [A01:2021-Broken Access Control]", pid, d.Taxonomy.OWASPTop10)
+		}
 	}
 }

--- a/zap-kb/internal/output/confluence/exporter.go
+++ b/zap-kb/internal/output/confluence/exporter.go
@@ -2273,8 +2273,10 @@ func prependDefProperties(storageBody string, def *entities.Definition, jiraBase
 	// 4. CWE
 	if def.Taxonomy != nil && def.Taxonomy.CWEID > 0 {
 		label := fmt.Sprintf("CWE-%d", def.Taxonomy.CWEID)
-		if strings.TrimSpace(def.Taxonomy.CWEName) != "" {
-			label += ": " + def.Taxonomy.CWEName
+		// Skip the name when it is unresolved and merely echoes the id
+		// (e.g. CWEName "CWE-552"), which would render "CWE-552: CWE-552".
+		if n := strings.TrimSpace(def.Taxonomy.CWEName); n != "" && n != label {
+			label += ": " + n
 		}
 		link := fmt.Sprintf(`<a href="%s">%s</a>`, escapeAttr(cweURL(def.Taxonomy)), escapeHTML(label))
 		props = append(props, [2]string{"CWE", link})

--- a/zap-kb/internal/output/forgejo/forgejo_test.go
+++ b/zap-kb/internal/output/forgejo/forgejo_test.go
@@ -80,6 +80,30 @@ func TestExtractIssueNumber(t *testing.T) {
 	}
 }
 
+func TestClassificationMarkdown_SkipsEchoedCWEName(t *testing.T) {
+	// An unresolved CWE name that echoes the id must not render "CWE-552: CWE-552".
+	def := &entities.Definition{
+		Taxonomy: &entities.Taxonomy{CWEID: 552, CWEName: "CWE-552"},
+	}
+	got := classificationMarkdown(def)
+	if strings.Contains(got, "CWE-552: CWE-552") {
+		t.Errorf("rendered echoed CWE name:\n%s", got)
+	}
+	if !strings.Contains(got, "CWE-552") {
+		t.Errorf("expected CWE-552 id in output:\n%s", got)
+	}
+}
+
+func TestClassificationMarkdown_KeepsResolvedCWEName(t *testing.T) {
+	def := &entities.Definition{
+		Taxonomy: &entities.Taxonomy{CWEID: 552, CWEName: "Files or Directories Accessible to External Parties"},
+	}
+	got := classificationMarkdown(def)
+	if !strings.Contains(got, "CWE-552: Files or Directories Accessible to External Parties") {
+		t.Errorf("expected resolved CWE name in output:\n%s", got)
+	}
+}
+
 func sampleEntities() entities.EntitiesFile {
 	return entities.EntitiesFile{
 		SchemaVersion: "v1",

--- a/zap-kb/internal/output/forgejo/render.go
+++ b/zap-kb/internal/output/forgejo/render.go
@@ -108,7 +108,9 @@ func classificationMarkdown(def *entities.Definition) string {
 				url = fmt.Sprintf("https://cwe.mitre.org/data/definitions/%d.html", t.CWEID)
 			}
 			label := fmt.Sprintf("CWE-%d", t.CWEID)
-			if n := strings.TrimSpace(t.CWEName); n != "" {
+			// Skip the name when it is unresolved and merely echoes the id
+			// (e.g. CWEName "CWE-552"), which would render "CWE-552: CWE-552".
+			if n := strings.TrimSpace(t.CWEName); n != "" && n != label {
 				label += ": " + n
 			}
 			lines = append(lines, fmt.Sprintf("- **CWE:** [%s](%s)", label, url))

--- a/zap-kb/internal/output/jira/taxonomy.go
+++ b/zap-kb/internal/output/jira/taxonomy.go
@@ -72,8 +72,10 @@ func cvssLine(cvss *entities.CVSS) string {
 
 func cweLabel(t *entities.Taxonomy) string {
 	label := fmt.Sprintf("CWE-%d", t.CWEID)
-	if strings.TrimSpace(t.CWEName) != "" {
-		label += ": " + strings.TrimSpace(t.CWEName)
+	// Skip the name when it is unresolved and merely echoes the id
+	// (e.g. CWEName "CWE-552"), which would render "CWE-552: CWE-552".
+	if n := strings.TrimSpace(t.CWEName); n != "" && n != label {
+		label += ": " + n
 	}
 	return label
 }

--- a/zap-kb/internal/output/obsidian/obsidian.go
+++ b/zap-kb/internal/output/obsidian/obsidian.go
@@ -412,8 +412,10 @@ func WriteVault(root string, ef entities.EntitiesFile, opts Options) error {
 			lines := []string{}
 			if d.Taxonomy.CWEID > 0 {
 				cweLine := fmt.Sprintf("CWE-%d", d.Taxonomy.CWEID)
-				if strings.TrimSpace(d.Taxonomy.CWEName) != "" {
-					cweLine += ": " + d.Taxonomy.CWEName
+				// Skip the name when it is unresolved and merely echoes the id
+				// (e.g. CWEName "CWE-552"), which would render "CWE-552: CWE-552".
+				if n := strings.TrimSpace(d.Taxonomy.CWEName); n != "" && n != cweLine {
+					cweLine += ": " + n
 				}
 				lines = append(lines, cweLine)
 			}

--- a/zap-kb/internal/zapmeta/custom_taxonomy.go
+++ b/zap-kb/internal/zapmeta/custom_taxonomy.go
@@ -1,5 +1,10 @@
 package zapmeta
 
+import (
+	"strconv"
+	"strings"
+)
+
 // CustomTaxonomy holds static taxonomy overrides for custom/internal ZAP rule plugin IDs
 // that are not in the standard ZAP alerts catalogue.
 type CustomTaxonomy struct {
@@ -10,42 +15,109 @@ type CustomTaxonomy struct {
 	OWASPTop10 []string
 }
 
-// customTaxonomyMap maps plugin IDs to their static taxonomy.
-// The 4 authenticated-* rules are custom IDOR/access-control findings.
-var customTaxonomyMap = map[string]CustomTaxonomy{
-	"zap-authenticated-basket-item-enumeration": {
-		CWEID:      639,
-		CWEURI:     "https://cwe.mitre.org/data/definitions/639.html",
-		CAPECIDs:   []int{122},
-		ATTACK:     []string{"T1078"},
-		OWASPTop10: []string{"A01:2021-Broken Access Control"},
-	},
-	"zap-authenticated-basket-object-reference-exposure": {
-		CWEID:      639,
-		CWEURI:     "https://cwe.mitre.org/data/definitions/639.html",
-		CAPECIDs:   []int{122},
-		ATTACK:     []string{"T1078"},
-		OWASPTop10: []string{"A01:2021-Broken Access Control"},
-	},
-	"zap-authenticated-complaints-exposure": {
-		CWEID:      639,
-		CWEURI:     "https://cwe.mitre.org/data/definitions/639.html",
-		CAPECIDs:   []int{122},
-		ATTACK:     []string{"T1078"},
-		OWASPTop10: []string{"A01:2021-Broken Access Control"},
-	},
-	"zap-authenticated-user-directory-exposure": {
-		CWEID:      639,
-		CWEURI:     "https://cwe.mitre.org/data/definitions/639.html",
-		CAPECIDs:   []int{122},
-		ATTACK:     []string{"T1078"},
-		OWASPTop10: []string{"A01:2021-Broken Access Control"},
-	},
+// knownSourcePrefixes are the scanner/source tokens the devsecopskb pipeline
+// prepends to every imported rule identifier (e.g. "zap-10098",
+// "nuclei-missing-hsts-header", "zap-missing-referrer-policy"). The same logical
+// rule is imported once per source tool, so these prefixes are stripped before
+// any taxonomy lookup — otherwise a curated entry would have to enumerate every
+// source variant and would silently miss new ones.
+var knownSourcePrefixes = []string{"zap-", "nuclei-", "burp-"}
+
+// CanonicalPluginID returns the source-agnostic lookup key for a plugin ID. It
+// trims an optional "custom-" marker (the pipeline tags KB-authored rules
+// "custom-nuclei-…"/"custom-zap-…") and then one known source prefix:
+//
+//	"zap-10098"                          → "10098"   (ZAP numeric plugin)
+//	"custom-nuclei-missing-hsts-header"  → "missing-hsts-header"
+//	"custom-zap-jwt-password-hash-disclosure" → "jwt-password-hash-disclosure"
+//	"nuclei-missing-referrer-policy"     → "missing-referrer-policy"
+//	"missing-hsts-header"                → "missing-hsts-header" (already canonical)
+//
+// Matching is case-insensitive; one "custom-" and one source prefix are removed.
+func CanonicalPluginID(pluginID string) string {
+	id := strings.TrimSpace(pluginID)
+	if strings.HasPrefix(strings.ToLower(id), "custom-") {
+		id = id[len("custom-"):]
+	}
+	lower := strings.ToLower(id)
+	for _, p := range knownSourcePrefixes {
+		if strings.HasPrefix(lower, p) {
+			return id[len(p):]
+		}
+	}
+	return id
 }
 
-// LookupCustomTaxonomy returns the static taxonomy for a plugin ID, or nil if not found.
+func cweURI(id int) string {
+	return "https://cwe.mitre.org/data/definitions/" + strconv.Itoa(id) + ".html"
+}
+
+// Shared mappings for custom-rule families.
+var (
+	// IDOR / broken access control (the authenticated-access rules).
+	idorTaxonomy = CustomTaxonomy{
+		CWEID: 639, CWEURI: cweURI(639), CAPECIDs: []int{122},
+		ATTACK: []string{"T1078"}, OWASPTop10: []string{"A01:2021-Broken Access Control"},
+	}
+	// Sensitive information exposed to unauthenticated callers.
+	infoExposureTaxonomy = CustomTaxonomy{
+		CWEID: 200, CWEURI: cweURI(200), CAPECIDs: []int{118}, OWASPTop10: []string{"A05:2021"},
+	}
+	// Error/stack-trace responses leaking internal detail.
+	errorDisclosureTaxonomy = CustomTaxonomy{
+		CWEID: 209, CWEURI: cweURI(209), CAPECIDs: []int{118}, OWASPTop10: []string{"A05:2021"},
+	}
+)
+
+// customTaxonomyMap maps the CANONICAL (prefix-stripped) plugin ID of a custom /
+// KB-authored rule to its static taxonomy. Keys are the source-agnostic slug the
+// pipeline emits after the "custom-"/"zap-"/"nuclei-" prefixes — see
+// CanonicalPluginID. Because custom rules are KB-owned, every custom rule the KB
+// publishes MUST appear here: an unmapped custom rule is deliberately left with
+// blank taxonomy ("Taxonomy incomplete") rather than inheriting the scanner's
+// generic placeholder CWE. The export prints a diagnostic listing any custom
+// rule that lands here without a mapping.
+var customTaxonomyMap = map[string]CustomTaxonomy{
+	// --- Access control (IDOR) ---
+	"auth-basket-items-enumeration": idorTaxonomy,
+	"auth-basket-object-reference":  idorTaxonomy,
+	"auth-complaints-exposure":      idorTaxonomy,
+	"auth-user-directory-exposure":  idorTaxonomy,
+
+	// --- Unauthenticated information exposure ---
+	"public-application-configuration": infoExposureTaxonomy,
+	"public-challenge-metadata":        infoExposureTaxonomy,
+	"public-feedback-exposure":         infoExposureTaxonomy,
+	"robots-sensitive-paths":           infoExposureTaxonomy,
+
+	// --- Error / stack-trace disclosure ---
+	"captcha-route-error-disclosure": errorDisclosureTaxonomy,
+	"stacktrace-disclosure":          errorDisclosureTaxonomy,
+
+	// --- Response-header hardening ---
+	// HSTS absent → cleartext transmission exposure.
+	"missing-hsts-header": {CWEID: 319, CWEURI: cweURI(319), OWASPTop10: []string{"A02:2021"}},
+	// Referrer-Policy absent → sensitive information disclosure via Referer.
+	"missing-referrer-policy": {CWEID: 200, CWEURI: cweURI(200), OWASPTop10: []string{"A05:2021"}},
+	// CSP absent → protection-mechanism failure enabling client-side injection.
+	"missing-csp": {CWEID: 693, CWEURI: cweURI(693), CAPECIDs: []int{63}, OWASPTop10: []string{"A05:2021"}},
+	// Permissive CORS (wildcard origin).
+	"wildcard-cors-origin": {CWEID: 942, CWEURI: cweURI(942), CAPECIDs: []int{1}, OWASPTop10: []string{"A05:2021"}},
+
+	// --- Other KB-authored rules ---
+	// Legacy FTP content reachable over the web root.
+	"legacy-ftp-surface": {CWEID: 552, CWEURI: cweURI(552), OWASPTop10: []string{"A01:2021-Broken Access Control"}},
+	// Error-based SQL injection.
+	"sql-error-based-injection": {CWEID: 89, CWEURI: cweURI(89), CAPECIDs: []int{66}, OWASPTop10: []string{"A03:2021"}},
+	// Credential hash embedded in a token → cryptographic failure. CWE-522 is the
+	// precise weakness, more so than the scanner's generic CWE-200.
+	"jwt-password-hash-disclosure": {CWEID: 522, CWEURI: cweURI(522), OWASPTop10: []string{"A02:2021"}},
+}
+
+// LookupCustomTaxonomy returns the static taxonomy for a plugin ID, or nil if not
+// found. The ID is canonicalized so every source variant maps to one entry.
 func LookupCustomTaxonomy(pluginID string) *CustomTaxonomy {
-	t, ok := customTaxonomyMap[pluginID]
+	t, ok := customTaxonomyMap[CanonicalPluginID(pluginID)]
 	if !ok {
 		return nil
 	}
@@ -87,9 +159,11 @@ var falsePositiveMap = map[string]FalsePositiveGuidance{
 	},
 }
 
-// LookupFalsePositiveGuidance returns FP conditions for a plugin ID, or nil if not found.
+// LookupFalsePositiveGuidance returns FP conditions for a plugin ID, or nil if
+// not found. The ID is canonicalized so source-prefixed IDs (e.g. "zap-10098")
+// match the numeric falsePositiveMap keys.
 func LookupFalsePositiveGuidance(pluginID string) *FalsePositiveGuidance {
-	g, ok := falsePositiveMap[pluginID]
+	g, ok := falsePositiveMap[CanonicalPluginID(pluginID)]
 	if !ok {
 		return nil
 	}

--- a/zap-kb/internal/zapmeta/mitre.go
+++ b/zap-kb/internal/zapmeta/mitre.go
@@ -101,8 +101,10 @@ var cweNames = map[int]string{
 	327:  "Use of a Broken or Risky Cryptographic Algorithm",
 	345:  "Insufficient Verification of Data Authenticity",
 	502:  "Deserialization of Untrusted Data",
+	522:  "Insufficiently Protected Credentials",
 	525:  "Use of Web Browser Cache Containing Sensitive Information",
 	549:  "Missing Password Field Masking",
+	552:  "Files or Directories Accessible to External Parties",
 	565:  "Reliance on Cookies without Validation and Integrity Checking",
 	614:  "Sensitive Cookie in HTTPS Session Without Secure Attribute",
 	639:  "Authorization Bypass Through User-Controlled Key",
@@ -118,6 +120,7 @@ var cweNames = map[int]string{
 var capecNames = map[int]string{
 	1:   "Accessing Functionality Not Properly Constrained by ACLs",
 	37:  "Retrieve Embedded Sensitive Data",
+	63:  "Cross-Site Scripting (XSS)",
 	66:  "SQL Injection",
 	86:  "Cross-site Scripting",
 	118: "Data Leakage Attacks",

--- a/zap-kb/internal/zapmeta/zapmeta.go
+++ b/zap-kb/internal/zapmeta/zapmeta.go
@@ -68,7 +68,9 @@ var cweFallback = map[string]int{
 // ScrapeDetection best-effort scrapes ZAP alert docs for a plugin id and identifies
 // the implementing Java class path and logic type. Network failures return (nil, nil).
 func ScrapeDetection(ctx context.Context, pluginID string) (*Result, error) {
-	pid := strings.TrimLeft(strings.TrimSpace(pluginID), "0")
+	// Strip the source prefix ("zap-10098" → "10098") before deriving the docs
+	// URL and CWE fallback, then drop any leading zeros for the docs path.
+	pid := strings.TrimLeft(CanonicalPluginID(pluginID), "0")
 	if pid == "" {
 		return nil, nil
 	}
@@ -454,7 +456,7 @@ func fromRuleSource(ruleSource string) string {
 // cweFallback map — no network calls. Returns nil if the plugin ID is unknown.
 // This is intentionally lightweight for use in offline enrichment paths.
 func LookupPlugin(pluginID string) *Result {
-	pid := strings.TrimSpace(pluginID)
+	pid := CanonicalPluginID(pluginID)
 	if pid == "" {
 		return nil
 	}

--- a/zap-kb/internal/zapmeta/zapmeta_test.go
+++ b/zap-kb/internal/zapmeta/zapmeta_test.go
@@ -5,6 +5,57 @@ import (
 	"testing"
 )
 
+func TestCanonicalPluginID(t *testing.T) {
+	cases := map[string]string{
+		"zap-10098":                               "10098",
+		"nuclei-missing-hsts-header":              "missing-hsts-header",
+		"zap-missing-referrer-policy":             "missing-referrer-policy",
+		"missing-hsts-header":                     "missing-hsts-header",
+		"10098":                                   "10098",
+		"ZAP-10098":                               "10098",
+		"custom-nuclei-missing-hsts-header":       "missing-hsts-header",
+		"custom-zap-jwt-password-hash-disclosure": "jwt-password-hash-disclosure",
+		"custom-nuclei-auth-complaints-exposure":  "auth-complaints-exposure",
+	}
+	for in, want := range cases {
+		if got := CanonicalPluginID(in); got != want {
+			t.Errorf("CanonicalPluginID(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestLookupCustomTaxonomy_CanonicalizesSourcePrefix(t *testing.T) {
+	// Both source variants of the same logical rule resolve to one entry.
+	for _, pid := range []string{"nuclei-missing-hsts-header", "zap-missing-hsts-header", "missing-hsts-header"} {
+		ct := LookupCustomTaxonomy(pid)
+		if ct == nil || ct.CWEID != 319 {
+			t.Errorf("LookupCustomTaxonomy(%q) = %+v, want CWE-319", pid, ct)
+		}
+	}
+}
+
+func TestLookupFalsePositiveGuidance_CanonicalizesSourcePrefix(t *testing.T) {
+	// "zap-10098" must hit the numeric "10098" FP-guidance key.
+	if g := LookupFalsePositiveGuidance("zap-10098"); g == nil || len(g.Conditions) == 0 {
+		t.Errorf("LookupFalsePositiveGuidance(zap-10098) = %+v, want CDM guidance", g)
+	}
+}
+
+func TestLookupCWEInfo_552ResolvesToTitle(t *testing.T) {
+	// CWE-552 must resolve to its real title, not echo the id, so renderers do
+	// not produce "CWE-552: CWE-552" on FTP-surface findings.
+	ref := LookupCWEInfo(552)
+	if ref == nil {
+		t.Fatal("expected MITRERef for CWE-552")
+	}
+	if ref.Name != "Files or Directories Accessible to External Parties" {
+		t.Errorf("CWE-552 name = %q, want resolved title", ref.Name)
+	}
+	if ref.Name == ref.ID {
+		t.Errorf("CWE-552 name echoes id %q", ref.ID)
+	}
+}
+
 func TestScrapeCWEID_LinkInHTML(t *testing.T) {
 	html := `<a href="https://cwe.mitre.org/data/definitions/79.html">CWE-79</a>`
 	got := scrapeCWEID(html, "40012")


### PR DESCRIPTION
## Summary
Custom-rule taxonomy was silently never applied. The pipeline emits **source-prefixed** plugin IDs (`zap-*`, `nuclei-*`) but the zapmeta lookup maps were keyed by **unprefixed/stale** IDs, and `EnrichCustomTaxonomy` was **dead code never wired into the export**. Custom findings therefore inherited the scanner's generic **CWE-200** placeholder, and ZAP plugin 10098 kept its **deprecated CWE-264**.

Reproduced live in the Forgejo KB (`kbadmin/kb-demo`): IDOR findings (#18/#22/#10) labeled CWE-200/A05 instead of CWE-639/A01; #6 CDM CWE-264 + CAPEC-122; #7 JWT A05; #17 FTP `CWE-552: CWE-552`.

## Root-cause fixes
- `zapmeta.CanonicalPluginID` strips `custom-`/`zap-`/`nuclei-` prefixes; all lookups (`cweFallback`, `customTaxonomyMap`, `falsePositiveMap`) and `ScrapeDetection` canonicalize. Maps re-keyed to source-agnostic slugs.
- Wired `EnrichCustomTaxonomy` into the export **before** `EnrichTaxonomy`.
- **Custom rules are KB-owned**: scanner CWE treated as an untrusted placeholder; an unmapped custom rule is **blanked** ("Taxonomy incomplete") and `UnmappedCustomRules` prints a build diagnostic. Tool plugins (numeric ZAP ids) keep their scanner CWE.

## Taxonomy corrections (SME / Opus-agent reviewed)
| Finding | Before | After |
|---|---|---|
| CDM `def-10098` | CWE-264 + CAPEC-122 | CWE-942 + CAPEC-1 (via deprecation remap) |
| FTP `legacy-ftp-surface` | `CWE-552: CWE-552` | `CWE-552: Files or Directories Accessible to External Parties` / A01 |
| JWT password-hash | CWE-200 / A05 | CWE-522 / A02 |
| IDOR `auth-*` | CWE-200 / A05 | CWE-639 / A01 / CAPEC-122 / T1078 |
| Missing CSP | CWE-693 / CAPEC-1 | CWE-693 / CAPEC-63 (XSS) |
| HSTS / Referrer | "Taxonomy incomplete" | CWE-319/A02 · CWE-200/A05 |

Curated **every** custom rule the KB publishes (auth-*, public-*, missing-*, wildcard-cors, legacy-ftp, sql-error, stacktrace, jwt). Curated CWE/OWASP/CAPEC are authoritative for custom rules (heals JSON round-trips); ATT&CK additive.

## Tests
`go build`, `go vet`, `go test ./...` all green. Added unit + pipeline + renderer-guard tests (canonicalization, blank-unmapped, tool-not-blanked, diagnostic, deprecated-264 remap, CSP→XSS, IDOR round-trip).

## Follow-ups (not in this PR)
- **Upstream:** firing-range to emit `custom-nuclei-`/`custom-zap-` IDs (prompt drafted). The KB already consumes them.
- **Migration:** finding identity still uses the raw `pluginId`; canonicalizing identity (strip `custom-`) avoids duplicate issues when the upstream rename lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)