### PR TITLE
Forgejo sink follow-up hardening

### DIFF
--- a/zap-kb/cmd/zap-kb/forgejo_sync.go
+++ b/zap-kb/cmd/zap-kb/forgejo_sync.go
@@ -17,11 +17,12 @@ import (
 
 // defaultForgejoRedact is the redaction list applied to data published to
 // Forgejo (issue bodies and wiki pages) unless overridden. It scrubs
-// credential-bearing fields (Authorization, cookies, API-key headers) while
-// leaving URLs and evidence intact so issues stay actionable. Forgejo is a
-// shared export surface, so redaction is on by default; pass
-// -forgejo-redact=off to disable.
-const defaultForgejoRedact = "auth,cookies,headers"
+// credential-bearing headers (Authorization, cookies, API-key headers) and
+// credential/PII patterns in scanner evidence (password hashes, emails, JWTs)
+// while leaving URLs and the rest of the evidence intact so issues stay
+// actionable. Forgejo is a shared export surface, so redaction is on by
+// default; pass -forgejo-redact=off to disable.
+const defaultForgejoRedact = "auth,cookies,headers,secrets"
 
 // forgejoPublishOptions bundles everything runForgejoPublish needs: the Forgejo
 // connection + filtering knobs plus the vault/persistence context shared with

--- a/zap-kb/cmd/zap-kb/forgejo_sync.go
+++ b/zap-kb/cmd/zap-kb/forgejo_sync.go
@@ -37,6 +37,7 @@ type forgejoPublishOptions struct {
 	Concurrency  int
 	DryRun       bool
 	SyncKBStatus bool
+	Issues       bool // create/track one Forgejo issue per finding; off = wiki-only
 	Wiki         bool
 	WikiPrune    bool
 	Redact       string // redaction list for published content; "off"/"none" disables
@@ -140,81 +141,92 @@ func runForgejoPublish(ent *entities.EntitiesFile, opts forgejoPublishOptions) i
 		pubEnt = cp
 	}
 
-	// Link issues to the KB wiki definition page only when the wiki is being
-	// published this run, so issues never point at a wiki that does not exist.
-	wikiURLBase := ""
-	if opts.Wiki {
-		wikiURLBase = fmt.Sprintf("%s/%s/%s/wiki", strings.TrimRight(opts.BaseURL, "/"), opts.Owner, opts.Repo)
-	}
-
-	exCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
-	sum, err := forgejo.Export(exCtx, pubEnt, forgejo.Options{
-		BaseURL:     opts.BaseURL,
-		Token:       opts.Token,
-		Owner:       opts.Owner,
-		Repo:        opts.Repo,
-		ExtraLabels: opts.ExtraLabels,
-		MinRisk:     opts.MinRisk,
-		OptInTag:    opts.OptInTag,
-		DryRun:      opts.DryRun,
-		Concurrency: opts.Concurrency,
-		WikiURLBase: wikiURLBase,
-	})
-	if err != nil {
-		// A wholesale export failure (auth/connectivity) would fail the pull and
-		// wiki steps the same way; return early with a failure so CI/cron sees a
-		// non-zero exit, without aborting other sinks via log.Fatalf.
-		log.Printf("error: forgejo export: %v", err)
-		return failures + 1
-	}
-	fmt.Printf("Forgejo: created=%d reopened=%d updated=%d skipped=%d errors=%d duplicates_closed=%d\n",
-		sum.Created, sum.Reopened, sum.BodiesUpdated, sum.Skipped, sum.Errors, sum.DuplicatesClosed)
-	failures += sum.Errors
-
-	addedTicketKeys := 0
-	if !opts.DryRun && len(sum.TicketRefs) > 0 {
-		addedTicketKeys = mergeForgejoTicketRefs(ent, sum.TicketRefs, opts.Owner+"/"+opts.Repo)
-	}
-
-	// Pull issue state back. By default this is read-only (Forgejo is the
-	// workflow source of truth); -forgejo-sync-kb-status mutates KB status.
-	if !opts.DryRun && hasFindingTicketRefs(*ent) {
-		pullCtx, pcancel := context.WithTimeout(context.Background(), 5*time.Minute)
-		defer pcancel()
-		pres, perr := forgejo.PullStatus(pullCtx, *ent, forgejo.PullOptions{
-			BaseURL:  opts.BaseURL,
-			Token:    opts.Token,
-			Owner:    opts.Owner,
-			Repo:     opts.Repo,
-			ReadOnly: !opts.SyncKBStatus,
-		})
-		if perr != nil {
-			log.Printf("warning: forgejo status pull failed: %v", perr)
-		} else if opts.SyncKBStatus {
-			*ent = pres.Updated
-			fmt.Printf("Forgejo pull: updated=%d unchanged=%d notfound=%d unmapped=%d errors=%d\n",
-				pres.Result.Updated, pres.Result.Unchanged, pres.Result.NotFound, pres.Result.Unmapped, pres.Result.Errors)
-		} else {
-			fmt.Printf("Forgejo pull: fetched=%d notfound=%d errors=%d (KB status write-back disabled)\n",
-				pres.Result.Unchanged+pres.Result.Unmapped, pres.Result.NotFound, pres.Result.Errors)
+	// Per-finding issue publishing. Skipped in wiki-only mode
+	// (-forgejo-issues=false), where the Forgejo Issues tab is reserved for
+	// other use (e.g. analyst-filed tuning requests) and the KB is published
+	// solely as the wiki.
+	if opts.Issues {
+		// Link issues to the KB wiki definition page only when the wiki is being
+		// published this run, so issues never point at a wiki that does not exist.
+		wikiURLBase := ""
+		if opts.Wiki {
+			wikiURLBase = fmt.Sprintf("%s/%s/%s/wiki", strings.TrimRight(opts.BaseURL, "/"), opts.Owner, opts.Repo)
 		}
-	}
 
-	// Persist ticket refs / status back to the entities file so the next run
-	// short-circuits dedup. Reuses the shared persistence helper.
-	if !opts.DryRun && (addedTicketKeys > 0 || (opts.SyncKBStatus && hasFindingTicketRefs(*ent))) {
-		savePath, werr := persistJiraEntities(jiraSyncContext{
-			Format:           opts.Format,
-			Out:              opts.Out,
-			EntitiesIn:       opts.EntitiesIn,
-			RunIn:            opts.RunIn,
-			RunInputArtifact: opts.RunInArtifact,
-		}, *ent)
-		if werr != nil {
-			log.Printf("warning: could not save Forgejo state to entities file: %v", werr)
-		} else if savePath != "" {
-			fmt.Printf("Forgejo: wrote current ticket/state data to %s\n", savePath)
+		exCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
+		sum, err := forgejo.Export(exCtx, pubEnt, forgejo.Options{
+			BaseURL:     opts.BaseURL,
+			Token:       opts.Token,
+			Owner:       opts.Owner,
+			Repo:        opts.Repo,
+			ExtraLabels: opts.ExtraLabels,
+			MinRisk:     opts.MinRisk,
+			OptInTag:    opts.OptInTag,
+			DryRun:      opts.DryRun,
+			Concurrency: opts.Concurrency,
+			WikiURLBase: wikiURLBase,
+		})
+		if err != nil {
+			// A wholesale export failure (auth/connectivity) would fail the pull
+			// and wiki steps the same way; return early with a failure so CI/cron
+			// sees a non-zero exit, without aborting other sinks via log.Fatalf.
+			log.Printf("error: forgejo export: %v", err)
+			return failures + 1
+		}
+		fmt.Printf("Forgejo: created=%d reopened=%d updated=%d skipped=%d errors=%d duplicates_closed=%d\n",
+			sum.Created, sum.Reopened, sum.BodiesUpdated, sum.Skipped, sum.Errors, sum.DuplicatesClosed)
+		failures += sum.Errors
+
+		addedTicketKeys := 0
+		if !opts.DryRun && len(sum.TicketRefs) > 0 {
+			addedTicketKeys = mergeForgejoTicketRefs(ent, sum.TicketRefs, opts.Owner+"/"+opts.Repo)
+			// Mirror the refs into the publish view so the wiki snapshot rendered
+			// below links each finding to its issue on the FIRST publish. Without
+			// this the wiki was rendered from a copy taken before issues existed,
+			// so issue cross-links only appeared on a subsequent run.
+			mergeForgejoTicketRefs(&pubEnt, sum.TicketRefs, opts.Owner+"/"+opts.Repo)
+		}
+
+		// Pull issue state back. By default this is read-only (Forgejo is the
+		// workflow source of truth); -forgejo-sync-kb-status mutates KB status.
+		if !opts.DryRun && hasFindingTicketRefs(*ent) {
+			pullCtx, pcancel := context.WithTimeout(context.Background(), 5*time.Minute)
+			defer pcancel()
+			pres, perr := forgejo.PullStatus(pullCtx, *ent, forgejo.PullOptions{
+				BaseURL:  opts.BaseURL,
+				Token:    opts.Token,
+				Owner:    opts.Owner,
+				Repo:     opts.Repo,
+				ReadOnly: !opts.SyncKBStatus,
+			})
+			if perr != nil {
+				log.Printf("warning: forgejo status pull failed: %v", perr)
+			} else if opts.SyncKBStatus {
+				*ent = pres.Updated
+				fmt.Printf("Forgejo pull: updated=%d unchanged=%d notfound=%d unmapped=%d errors=%d\n",
+					pres.Result.Updated, pres.Result.Unchanged, pres.Result.NotFound, pres.Result.Unmapped, pres.Result.Errors)
+			} else {
+				fmt.Printf("Forgejo pull: fetched=%d notfound=%d errors=%d (KB status write-back disabled)\n",
+					pres.Result.Unchanged+pres.Result.Unmapped, pres.Result.NotFound, pres.Result.Errors)
+			}
+		}
+
+		// Persist ticket refs / status back to the entities file so the next run
+		// short-circuits dedup. Reuses the shared persistence helper.
+		if !opts.DryRun && (addedTicketKeys > 0 || (opts.SyncKBStatus && hasFindingTicketRefs(*ent))) {
+			savePath, werr := persistJiraEntities(jiraSyncContext{
+				Format:           opts.Format,
+				Out:              opts.Out,
+				EntitiesIn:       opts.EntitiesIn,
+				RunIn:            opts.RunIn,
+				RunInputArtifact: opts.RunInArtifact,
+			}, *ent)
+			if werr != nil {
+				log.Printf("warning: could not save Forgejo state to entities file: %v", werr)
+			} else if savePath != "" {
+				fmt.Printf("Forgejo: wrote current ticket/state data to %s\n", savePath)
+			}
 		}
 	}
 

--- a/zap-kb/cmd/zap-kb/forgejo_sync.go
+++ b/zap-kb/cmd/zap-kb/forgejo_sync.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Warlockobama/DevSecOpsKB/zap-kb/internal/entities"
 	"github.com/Warlockobama/DevSecOpsKB/zap-kb/internal/output/forgejo"
+	"github.com/Warlockobama/DevSecOpsKB/zap-kb/internal/output/obsidian"
 	"github.com/Warlockobama/DevSecOpsKB/zap-kb/internal/output/runartifact"
 )
 
@@ -63,6 +64,34 @@ func forgejoRedactOptions(list string) (entities.RedactOptions, bool) {
 		v = defaultForgejoRedact
 	}
 	return entities.ParseRedactOptionList(v), true
+}
+
+// forgejoTicketURL returns an obsidian.Options.TicketURLFn that resolves this
+// repo's issue refs ("owner/repo#42", "#42", bare "42", or a pasted browse
+// URL) to live Forgejo issue links. Refs for other trackers (Jira keys, other
+// repos) return "" and fall through to the vault's default handling.
+func forgejoTicketURL(baseURL, owner, repo string) func(string) string {
+	base := strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	repoPrefix := owner + "/" + repo
+	return func(ref string) string {
+		if n, ok := forgejo.ExtractIssueNumber(ref, repoPrefix); ok {
+			return fmt.Sprintf("%s/%s/%s/issues/%d", base, owner, repo, n)
+		}
+		return ""
+	}
+}
+
+// countOccurrencesWithTraffic reports how many occurrences carry a captured
+// request or response, so a publish without traffic is visible in the summary
+// instead of silently rendering placeholder evidence pages.
+func countOccurrencesWithTraffic(ent entities.EntitiesFile) int {
+	n := 0
+	for _, o := range ent.Occurrences {
+		if o.Request != nil || o.Response != nil {
+			n++
+		}
+	}
+	return n
 }
 
 // redactedCopy deep-copies an EntitiesFile via JSON round-trip and applies the
@@ -200,6 +229,26 @@ func runForgejoPublish(ent *entities.EntitiesFile, opts forgejoPublishOptions) i
 			failures++
 			return failures
 		}
+
+		// Surface traffic coverage before publishing: a wiki full of
+		// placeholder evidence pages usually means the run skipped
+		// -include-traffic (or published from saved entities with no live ZAP
+		// session), not a sink bug — say so up front.
+		trafficN := countOccurrencesWithTraffic(pubEnt)
+		fmt.Printf("Forgejo wiki: occurrences with traffic: %d/%d\n", trafficN, len(pubEnt.Occurrences))
+		if trafficN == 0 && len(pubEnt.Occurrences) > 0 {
+			log.Printf("warning: no occurrences carry HTTP request/response data — occurrence pages will show evidence placeholders; capture traffic with -include-traffic against a live ZAP session")
+		}
+
+		// The Forgejo-branded vault options: prose names Forgejo instead of
+		// Jira, and this repo's issue refs ("owner/repo#N") become live links.
+		vaultOpts := obsidian.Options{
+			ScanLabel:   opts.ScanLabel,
+			SiteLabel:   opts.SiteLabel,
+			ZapBaseURL:  opts.ZapBaseURL,
+			Tracker:     "Forgejo",
+			TicketURLFn: forgejoTicketURL(opts.BaseURL, opts.Owner, opts.Repo),
+		}
 		if redactOn {
 			tmp, terr := os.MkdirTemp("", "forgejo-wiki-vault-")
 			if terr != nil {
@@ -207,13 +256,13 @@ func runForgejoPublish(ent *entities.EntitiesFile, opts forgejoPublishOptions) i
 				return failures + 1
 			}
 			defer os.RemoveAll(tmp)
-			if err := writeVaultSnapshot(tmp, pubEnt, opts.ScanLabel, opts.SiteLabel, opts.ZapBaseURL, "", nil, nil, ""); err != nil {
+			if err := writeVaultSnapshot(tmp, pubEnt, vaultOpts); err != nil {
 				log.Printf("warning: could not write redacted vault for forgejo wiki: %v", err)
 				return failures + 1
 			}
 			wikiVault = tmp
 		} else if strings.TrimSpace(opts.Format) != "obsidian" {
-			if err := writeVaultSnapshot(wikiVault, pubEnt, opts.ScanLabel, opts.SiteLabel, opts.ZapBaseURL, "", nil, nil, ""); err != nil {
+			if err := writeVaultSnapshot(wikiVault, pubEnt, vaultOpts); err != nil {
 				log.Printf("warning: could not write vault for forgejo wiki: %v", err)
 				return failures + 1
 			}
@@ -232,7 +281,8 @@ func runForgejoPublish(ent *entities.EntitiesFile, opts forgejoPublishOptions) i
 			log.Printf("error: forgejo wiki export failed: %v", werr)
 			failures++
 		} else {
-			fmt.Printf("Forgejo wiki: created=%d updated=%d skipped=%d pruned=%d errors=%d\n", wsum.Created, wsum.Updated, wsum.Skipped, wsum.Pruned, wsum.Errors)
+			fmt.Printf("Forgejo wiki: created=%d updated=%d skipped=%d pruned=%d link_fixes=%d errors=%d\n",
+				wsum.Created, wsum.Updated, wsum.Skipped, wsum.Pruned, wsum.LinkFixes, wsum.Errors)
 			failures += wsum.Errors
 		}
 	}

--- a/zap-kb/cmd/zap-kb/forgejo_sync_test.go
+++ b/zap-kb/cmd/zap-kb/forgejo_sync_test.go
@@ -8,10 +8,10 @@ import (
 )
 
 func TestForgejoRedactOptions(t *testing.T) {
-	// Default (empty flag value) enables credential scrubbing.
+	// Default (empty flag value) enables credential + secrets scrubbing.
 	ro, on := forgejoRedactOptions("")
-	if !on || !ro.Auth || !ro.Cookies || !ro.Headers {
-		t.Fatalf("default = (%+v, %v), want auth/cookies/headers on", ro, on)
+	if !on || !ro.Auth || !ro.Cookies || !ro.Headers || !ro.Secrets {
+		t.Fatalf("default = (%+v, %v), want auth/cookies/headers/secrets on", ro, on)
 	}
 	if ro.Domain || ro.Body || ro.Notes {
 		t.Fatalf("default enabled extra modes: %+v", ro)

--- a/zap-kb/cmd/zap-kb/forgejo_sync_test.go
+++ b/zap-kb/cmd/zap-kb/forgejo_sync_test.go
@@ -165,9 +165,33 @@ func TestRunForgejoPublish_ExportErrorReturnsFailure(t *testing.T) {
 		Owner:   "acme",
 		Repo:    "kb",
 		MinRisk: "medium",
+		Issues:  true,
 		Redact:  "off",
 	})
 	if failures < 1 {
 		t.Fatalf("failures=%d, want >=1 (returned, not exited)", failures)
+	}
+}
+
+// Wiki-only mode (Issues=false) must not contact the issues API at all: with an
+// unreachable host and the wiki step off, the publish is a clean no-op rather
+// than an export failure, proving per-finding issue creation is skipped.
+func TestRunForgejoPublish_WikiOnlySkipsIssues(t *testing.T) {
+	ent := &entities.EntitiesFile{
+		SchemaVersion: "v1",
+		Findings:      []entities.Finding{{FindingID: "fin-1", URL: "https://t/a", Risk: "High", Occurrences: 1}},
+	}
+	failures := runForgejoPublish(ent, forgejoPublishOptions{
+		BaseURL: "http://127.0.0.1:1", // unreachable — would fail if contacted
+		Token:   "t",
+		Owner:   "acme",
+		Repo:    "kb",
+		MinRisk: "medium",
+		Issues:  false,
+		Wiki:    false,
+		Redact:  "off",
+	})
+	if failures != 0 {
+		t.Fatalf("failures=%d, want 0 (issues skipped, wiki off — nothing should be contacted)", failures)
 	}
 }

--- a/zap-kb/cmd/zap-kb/forgejo_sync_test.go
+++ b/zap-kb/cmd/zap-kb/forgejo_sync_test.go
@@ -29,6 +29,36 @@ func TestForgejoRedactOptions(t *testing.T) {
 	}
 }
 
+func TestForgejoTicketURL(t *testing.T) {
+	fn := forgejoTicketURL("https://forge.example/", "acme", "kb")
+	cases := []struct {
+		ref  string
+		want string
+	}{
+		{"acme/kb#7", "https://forge.example/acme/kb/issues/7"},
+		{"#12", "https://forge.example/acme/kb/issues/12"},
+		{"SEC-42", ""},       // Jira key — decline so the Jira fallback applies
+		{"other/repo#3", ""}, // different repo — never claim foreign refs
+		{"https://forge.example/acme/kb/issues/9", "https://forge.example/acme/kb/issues/9"},
+	}
+	for _, c := range cases {
+		if got := fn(c.ref); got != c.want {
+			t.Errorf("forgejoTicketURL(%q) = %q, want %q", c.ref, got, c.want)
+		}
+	}
+}
+
+func TestCountOccurrencesWithTraffic(t *testing.T) {
+	ent := entities.EntitiesFile{Occurrences: []entities.Occurrence{
+		{OccurrenceID: "a", Request: &entities.HTTPRequest{RawHeader: "GET / HTTP/1.1"}},
+		{OccurrenceID: "b", Response: &entities.HTTPResponse{RawHeader: "HTTP/1.1 200 OK"}},
+		{OccurrenceID: "c"},
+	}}
+	if got := countOccurrencesWithTraffic(ent); got != 2 {
+		t.Fatalf("countOccurrencesWithTraffic = %d, want 2", got)
+	}
+}
+
 func TestRedactedCopyScrubsWithoutMutatingOriginal(t *testing.T) {
 	const secret = "Bearer sup3r-s3cret-token"
 	ent := entities.EntitiesFile{

--- a/zap-kb/cmd/zap-kb/jira_sync.go
+++ b/zap-kb/cmd/zap-kb/jira_sync.go
@@ -160,19 +160,14 @@ func shouldCarryForwardOccurrenceMeta(sourceTool string) bool {
 	}
 }
 
-func writeVaultSnapshot(root string, ent entities.EntitiesFile, scanLabel, siteLabel, zapBase, jiraBase string, jiraStatusByKey, jiraAssigneeByKey map[string]string, jiraStatusSynced string) error {
-	return obsidian.WriteVault(root, ent, obsidian.Options{
-		ScanLabel:                  scanLabel,
-		SiteLabel:                  siteLabel,
-		ZapBaseURL:                 zapBase,
-		JiraBaseURL:                jiraBase,
-		JiraStatusByKey:            jiraStatusByKey,
-		JiraAssigneeByKey:          jiraAssigneeByKey,
-		JiraStatusSynced:           jiraStatusSynced,
-		TriageGuidanceFn:           zapmeta.TriageGuidance,
-		CarryForwardOccurrenceMeta: shouldCarryForwardOccurrenceMeta(ent.SourceTool),
-		CarryForwardFindingMeta:    shouldCarryForwardOccurrenceMeta(ent.SourceTool),
-	})
+// writeVaultSnapshot writes the Obsidian vault with the pipeline's standard
+// triage guidance and carry-forward policy applied on top of the caller's
+// sink-specific options (Jira fields, tracker name, ticket linkifier, …).
+func writeVaultSnapshot(root string, ent entities.EntitiesFile, opts obsidian.Options) error {
+	opts.TriageGuidanceFn = zapmeta.TriageGuidance
+	opts.CarryForwardOccurrenceMeta = shouldCarryForwardOccurrenceMeta(ent.SourceTool)
+	opts.CarryForwardFindingMeta = shouldCarryForwardOccurrenceMeta(ent.SourceTool)
+	return obsidian.WriteVault(root, ent, opts)
 }
 
 func publishConfluenceVault(vault, format string, ent entities.EntitiesFile, opts confluencePublishOptions) (confluence.VaultSummary, error) {
@@ -183,7 +178,15 @@ func publishConfluenceVault(vault, format string, ent entities.EntitiesFile, opt
 		return confluence.VaultSummary{}, fmt.Errorf("vault path is required for Confluence export")
 	}
 	if strings.TrimSpace(format) != "obsidian" {
-		if err := writeVaultSnapshot(vault, ent, opts.ScanLabel, opts.SiteLabel, opts.ZapBaseURL, opts.JiraBaseURL, opts.JiraStatusByKey, opts.JiraAssigneeByKey, opts.JiraStatusSynced); err != nil {
+		if err := writeVaultSnapshot(vault, ent, obsidian.Options{
+			ScanLabel:         opts.ScanLabel,
+			SiteLabel:         opts.SiteLabel,
+			ZapBaseURL:        opts.ZapBaseURL,
+			JiraBaseURL:       opts.JiraBaseURL,
+			JiraStatusByKey:   opts.JiraStatusByKey,
+			JiraAssigneeByKey: opts.JiraAssigneeByKey,
+			JiraStatusSynced:  opts.JiraStatusSynced,
+		}); err != nil {
 			return confluence.VaultSummary{}, fmt.Errorf("write obsidian for confluence: %w", err)
 		}
 	}

--- a/zap-kb/cmd/zap-kb/main.go
+++ b/zap-kb/cmd/zap-kb/main.go
@@ -108,6 +108,7 @@ func main() {
 		forgejoConcurrency  int
 		forgejoDryRun       bool
 		forgejoSyncKBStatus bool
+		forgejoIssues       bool
 		forgejoWiki         bool
 		forgejoWikiPrune    bool
 		forgejoRedact       string
@@ -199,6 +200,7 @@ func main() {
 	flag.IntVar(&forgejoConcurrency, "forgejo-concurrency", 3, "Max parallel Forgejo API requests (default: 3, max: 5).")
 	flag.BoolVar(&forgejoDryRun, "forgejo-dry-run", false, "Dry-run Forgejo export (log instead of POST).")
 	flag.BoolVar(&forgejoSyncKBStatus, "forgejo-sync-kb-status", false, "Write mapped Forgejo issue state/labels back into KB analyst status. By default Forgejo is the workflow source of truth and KB state is not mutated.")
+	flag.BoolVar(&forgejoIssues, "forgejo-issues", true, "Create/track one Forgejo issue per finding. Set false for wiki-only publishing, leaving the Issues tab free for other use (e.g. analyst-filed tuning requests).")
 	flag.BoolVar(&forgejoWiki, "forgejo-wiki", false, "Also publish the generated Obsidian vault to the Forgejo repo wiki (Confluence analog).")
 	flag.BoolVar(&forgejoWikiPrune, "forgejo-wiki-prune", false, "Delete KB-owned Forgejo wiki pages (Definitions/Findings/Occurrences) that are absent from the current publish.")
 	flag.StringVar(&forgejoRedact, "forgejo-redact", defaultForgejoRedact, "Redactions applied to content published to Forgejo (issues + wiki): comma list of domain,query,cookies,auth,headers,body,notes; 'off' disables. The local entities file keeps unredacted data.")
@@ -866,6 +868,9 @@ func main() {
 	// model, so any detection source feeding the KB publishes through it.
 	var forgejoFailures int
 	if strings.TrimSpace(forgejoURL) != "" {
+		if !forgejoIssues && !forgejoWiki {
+			log.Fatalf("-forgejo-issues=false with -forgejo-wiki unset leaves nothing to publish; enable one")
+		}
 		var extraLabels []string
 		for _, l := range strings.Split(forgejoLabels, ",") {
 			if l = strings.TrimSpace(l); l != "" {
@@ -887,6 +892,7 @@ func main() {
 			Concurrency:   forgejoConcurrency,
 			DryRun:        forgejoDryRun,
 			SyncKBStatus:  forgejoSyncKBStatus,
+			Issues:        forgejoIssues,
 			Wiki:          forgejoWiki,
 			WikiPrune:     forgejoWikiPrune,
 			Redact:        forgejoRedact,

--- a/zap-kb/cmd/zap-kb/main.go
+++ b/zap-kb/cmd/zap-kb/main.go
@@ -656,7 +656,12 @@ func main() {
 			log.Fatalf("write json entities: %v", err)
 		}
 	case "obsidian":
-		if err := writeVaultSnapshot(vault, ent, scanLabel, siteLabel, zapBase, jiraURL, nil, nil, ""); err != nil {
+		if err := writeVaultSnapshot(vault, ent, obsidian.Options{
+			ScanLabel:   scanLabel,
+			SiteLabel:   siteLabel,
+			ZapBaseURL:  zapBase,
+			JiraBaseURL: jiraURL,
+		}); err != nil {
 			log.Fatalf("write obsidian: %v", err)
 		}
 	default:
@@ -796,7 +801,15 @@ func main() {
 			}
 		}
 		if format == "obsidian" && !jiraDryRun && hasFindingTicketRefs(ent) {
-			if err := writeVaultSnapshot(vault, ent, scanLabel, siteLabel, zapBase, jiraURL, jiraStatusByKey, jiraAssigneeByKey, jiraStatusSynced); err != nil {
+			if err := writeVaultSnapshot(vault, ent, obsidian.Options{
+				ScanLabel:         scanLabel,
+				SiteLabel:         siteLabel,
+				ZapBaseURL:        zapBase,
+				JiraBaseURL:       jiraURL,
+				JiraStatusByKey:   jiraStatusByKey,
+				JiraAssigneeByKey: jiraAssigneeByKey,
+				JiraStatusSynced:  jiraStatusSynced,
+			}); err != nil {
 				log.Fatalf("rewrite obsidian after jira: %v", err)
 			}
 		}

--- a/zap-kb/cmd/zap-kb/main.go
+++ b/zap-kb/cmd/zap-kb/main.go
@@ -203,7 +203,7 @@ func main() {
 	flag.BoolVar(&forgejoIssues, "forgejo-issues", true, "Create/track one Forgejo issue per finding. Set false for wiki-only publishing, leaving the Issues tab free for other use (e.g. analyst-filed tuning requests).")
 	flag.BoolVar(&forgejoWiki, "forgejo-wiki", false, "Also publish the generated Obsidian vault to the Forgejo repo wiki (Confluence analog).")
 	flag.BoolVar(&forgejoWikiPrune, "forgejo-wiki-prune", false, "Delete KB-owned Forgejo wiki pages (Definitions/Findings/Occurrences) that are absent from the current publish.")
-	flag.StringVar(&forgejoRedact, "forgejo-redact", defaultForgejoRedact, "Redactions applied to content published to Forgejo (issues + wiki): comma list of domain,query,cookies,auth,headers,body,notes; 'off' disables. The local entities file keeps unredacted data.")
+	flag.StringVar(&forgejoRedact, "forgejo-redact", defaultForgejoRedact, "Redactions applied to content published to Forgejo (issues + wiki): comma list of domain,query,cookies,auth,headers,body,notes,secrets; 'off' disables. 'secrets' scrubs credential/PII patterns (hashes, emails, JWTs) from evidence. The local entities file keeps unredacted data.")
 	flag.BoolVar(&allowAgentPublish, "allow-agent-publish", false, "Allow Confluence/Jira publish from sourceTool values like zap-agent (disabled by default)")
 	flag.BoolVar(&allowCustomPublish, "allow-custom-publish", false, "Allow Confluence/Jira publish when the input contains custom definitions (disabled by default)")
 	flag.BoolVar(&zapAlertsOnly, "zap-alerts-only", false, "Keep only scanner-native ZAP alerts with numeric plugin IDs; excludes custom/project detections and other scanner sources.")

--- a/zap-kb/docs/forgejo-workflow.md
+++ b/zap-kb/docs/forgejo-workflow.md
@@ -1,0 +1,83 @@
+# Forgejo Workflow Convention
+
+How analyst workflow state is expressed on Forgejo, which only has a coarse
+open/closed issue state instead of Jira's configurable workflow engine. The
+gap is closed with a **label-state convention**: labels carry triage
+granularity, open/closed carries resolution, and the sink maps both back to
+the KB's canonical statuses.
+
+## Source of truth
+
+Forgejo Issues are the workflow source of truth for the Forgejo sink (the
+analog of Jira in the Atlassian deployment). The KB is the evidence and
+reporting surface:
+
+- The sink creates one issue per qualifying finding (default `-forgejo-min-risk
+  medium`; lower-severity findings opt in via the `case-ticket` analyst tag).
+- The wiki (published with `-forgejo-wiki`) is the evidence view — the
+  Confluence analog. Pages are machine-owned and overwritten on every publish.
+- Analyst decisions live on the issue: comments, assignees, labels, and the
+  open/closed state. Do **not** record workflow decisions by editing wiki
+  pages or generated KB status fields.
+
+## Canonical statuses and their label mapping
+
+The KB recognizes five analyst statuses: `open`, `triaged`, `fixed`,
+`accepted`, `fp`. On Forgejo they are expressed as:
+
+| KB status  | Forgejo expression |
+|------------|--------------------|
+| `open`     | Issue open, no workflow label |
+| `triaged`  | Issue open + a `triaged`, `in-progress`, `in-review`, `review`, or `under-review` label |
+| `fixed`    | Issue **closed** (no fp/accepted label), or a `fixed`, `resolved`, `done`, or `completed` label |
+| `accepted` | `accepted`, `risk-accepted`, `wontfix`, or `mitigated` label |
+| `fp`       | `false-positive`, `fp`, `not-a-bug`, or `not-applicable` label |
+
+Notes on the mapping (implemented in `internal/output/forgejo/status.go`):
+
+- **Labels win over state.** A closed issue labeled `false-positive` maps to
+  `fp`, not `fixed` — closing is how you end work, the label says *why*.
+- Label matching is case-insensitive and separator-insensitive:
+  `risk-accepted`, `risk_accepted`, and `Risk Accepted` are equivalent.
+- When closing as anything other than fixed, **apply the label first, then
+  close** (or in one edit) so an intervening status pull never reads the
+  closed issue as `fixed`.
+
+## Labels owned by the sink
+
+The sink creates and manages these — do not repurpose them:
+
+- `kb-finding` — marks an issue as KB-managed; the dedup scan is scoped to it.
+- `risk/high`, `risk/medium`, `risk/low`, `risk/info` — severity, restamped
+  from scanner data on every publish.
+- Extra static labels from `-forgejo-labels` (e.g. a team or service tag).
+
+Everything else on the issue is yours: assignees, milestones, comments,
+additional labels, and the workflow labels above.
+
+## Status flow back into the KB
+
+- By default the publish performs a **read-only** status pull: it reports
+  mapped statuses but does not mutate KB analyst fields (Forgejo stays the
+  source of truth).
+- With `-forgejo-sync-kb-status` the mapped status is written back into
+  `analyst.status` and persisted to the entities file — use this only when a
+  downstream consumer needs KB-side status snapshots.
+- Issue bodies are machine-owned and refreshed on every run (evidence,
+  occurrence counts, wiki links). Analyst commentary belongs in comments.
+- A finding that recurs after its issue was closed gets the issue
+  **reopened** with a comment, not a duplicate issue.
+
+## Jira parity notes
+
+| Jira capability | Forgejo answer |
+|-----------------|----------------|
+| Workflow states | Label-state convention above (open/closed + labels) |
+| JQL / reporting | The KB itself: triage board, dashboard, executive summary pages |
+| Assignment      | Native issue assignees |
+| Automation      | Forgejo Actions + webhooks on label/state changes |
+| Ticket links    | `owner/repo#N` refs in `analyst.ticketRefs`, linkified in the wiki |
+
+Known non-goals: multi-step approval workflows and custom field schemes have
+no Forgejo equivalent — keep those in the KB's governance fields (suppression
+records, acceptance expiry) where they already live.

--- a/zap-kb/internal/entities/redact.go
+++ b/zap-kb/internal/entities/redact.go
@@ -3,6 +3,7 @@ package entities
 import (
 	neturl "net/url"
 	"path"
+	"regexp"
 	"strings"
 )
 
@@ -18,6 +19,12 @@ import (
 //	notes    - zero analyst-authored free text (Analyst.Notes, Analyst.Rationale)
 //	           and scanner-supplied reproduction steps (Reproduce.Steps[]) that
 //	           can inadvertently carry pasted credentials or PII.
+//	secrets  - scrub credential/PII patterns (password hashes, emails, JWTs)
+//	           OUT OF the free-text scanner evidence (Occurrence.Evidence,
+//	           Attack, Name, Reproduce.Curl) while leaving the rest of the
+//	           snippet intact — unlike body, which drops the whole field. Keeps
+//	           captured secrets off a shared KB without gutting actionable
+//	           evidence (e.g. "SQLITE_ERROR: incomplete input" survives).
 type RedactOptions struct {
 	Domain  bool
 	Query   bool
@@ -26,6 +33,32 @@ type RedactOptions struct {
 	Headers bool
 	Body    bool
 	Notes   bool
+	Secrets bool
+}
+
+var (
+	// reSecretEmail matches email addresses captured in evidence (PII).
+	reSecretEmail = regexp.MustCompile(`[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}`)
+	// reSecretJWT matches a JWT (header.payload.signature, base64url) — these
+	// carry session/identity material and, in Juice Shop's case, a password hash.
+	reSecretJWT = regexp.MustCompile(`eyJ[A-Za-z0-9_\-]{4,}\.[A-Za-z0-9_\-]{4,}\.[A-Za-z0-9_\-]+`)
+	// reSecretHash matches a contiguous hex run the length of a common digest
+	// (MD5/SHA-1/SHA-256/…), i.e. a captured password/credential hash. Bounded
+	// by \b so occurrence IDs and short scan tokens are not caught.
+	reSecretHash = regexp.MustCompile(`\b[a-fA-F0-9]{32,128}\b`)
+)
+
+// redactSecretsText scrubs credential/PII patterns from a free-text scanner
+// string, replacing each match with a labeled placeholder. JWT is scrubbed
+// before the hash rule so its base64url segments are not partially masked.
+func redactSecretsText(s string) string {
+	if s == "" {
+		return s
+	}
+	s = reSecretJWT.ReplaceAllString(s, "<redacted-token>")
+	s = reSecretEmail.ReplaceAllString(s, "<redacted-email>")
+	s = reSecretHash.ReplaceAllString(s, "<redacted-hash>")
+	return s
 }
 
 func ParseRedactOptionList(list string) RedactOptions {
@@ -46,6 +79,8 @@ func ParseRedactOptionList(list string) RedactOptions {
 			ro.Body = true
 		case "notes", "note":
 			ro.Notes = true
+		case "secrets", "secret", "pii", "credentials":
+			ro.Secrets = true
 		}
 	}
 	return ro
@@ -59,6 +94,9 @@ func RedactEntities(e *EntitiesFile, ro RedactOptions) {
 		if ro.Notes && e.Findings[i].Analyst != nil {
 			e.Findings[i].Analyst.Notes = ""
 			e.Findings[i].Analyst.Rationale = ""
+		}
+		if ro.Secrets {
+			e.Findings[i].Name = redactSecretsText(e.Findings[i].Name)
 		}
 		if ro.Domain || ro.Query {
 			e.Findings[i].URL = redactURL(e.Findings[i].URL, ro)
@@ -116,6 +154,16 @@ func RedactEntities(e *EntitiesFile, ro RedactOptions) {
 			e.Occurrences[i].Evidence = ""
 			if e.Occurrences[i].Reproduce != nil {
 				e.Occurrences[i].Reproduce.Curl = ""
+			}
+		}
+		// secrets mode: surgically scrub credential/PII patterns from the
+		// free-text scanner fields, keeping the rest of the evidence usable.
+		if ro.Secrets {
+			e.Occurrences[i].Evidence = redactSecretsText(e.Occurrences[i].Evidence)
+			e.Occurrences[i].Attack = redactSecretsText(e.Occurrences[i].Attack)
+			e.Occurrences[i].Name = redactSecretsText(e.Occurrences[i].Name)
+			if e.Occurrences[i].Reproduce != nil {
+				e.Occurrences[i].Reproduce.Curl = redactSecretsText(e.Occurrences[i].Reproduce.Curl)
 			}
 		}
 		// auth mode: scrub auth headers embedded in Reproduce.Curl

--- a/zap-kb/internal/entities/redact_test.go
+++ b/zap-kb/internal/entities/redact_test.go
@@ -31,6 +31,49 @@ func makeOccurrenceWithRawHeaders(cookie, auth string) Occurrence {
 	}
 }
 
+// TestRedactSecrets_ScrubsCredentialPatternsKeepsEvidence verifies the secrets
+// mode removes captured password hashes, emails, and JWTs from free-text
+// evidence while leaving the actionable parts of the snippet intact.
+func TestRedactSecrets_ScrubsCredentialPatternsKeepsEvidence(t *testing.T) {
+	e := &EntitiesFile{
+		Occurrences: []Occurrence{{
+			OccurrenceID: "occ-1",
+			Evidence:     "user_id=23 received user id=1 email=admin@juice-sh.op role=admin hash=dd00510c9c75a85d9e43e1920b31d8e4",
+			Attack:       "token eyJhbGciOiJIUzI1Ni9.eyJzdWIiOiIxIn0.abc123",
+		}},
+	}
+	RedactEntities(e, RedactOptions{Secrets: true})
+	ev := e.Occurrences[0].Evidence
+	if strings.Contains(ev, "dd00510c9c75a85d9e43e1920b31d8e4") {
+		t.Errorf("password hash survived: %q", ev)
+	}
+	if strings.Contains(ev, "admin@juice-sh.op") {
+		t.Errorf("email survived: %q", ev)
+	}
+	// Useful, non-secret context must survive.
+	if !strings.Contains(ev, "role=admin") || !strings.Contains(ev, "user_id=23") {
+		t.Errorf("redaction gutted useful evidence: %q", ev)
+	}
+	if strings.Contains(e.Occurrences[0].Attack, "eyJhbGci") {
+		t.Errorf("JWT survived in attack: %q", e.Occurrences[0].Attack)
+	}
+}
+
+// A non-secret hex token shorter than a digest must NOT be scrubbed (no
+// false-positive masking of scan/occurrence IDs).
+func TestRedactSecrets_LeavesShortHexAndPlainEvidence(t *testing.T) {
+	e := &EntitiesFile{
+		Occurrences: []Occurrence{{
+			OccurrenceID: "occ-1",
+			Evidence:     "SQLITE_ERROR: incomplete input (run 20cbbd98)",
+		}},
+	}
+	RedactEntities(e, RedactOptions{Secrets: true})
+	if e.Occurrences[0].Evidence != "SQLITE_ERROR: incomplete input (run 20cbbd98)" {
+		t.Errorf("plain evidence wrongly altered: %q", e.Occurrences[0].Evidence)
+	}
+}
+
 // Raw header blocks are now scrubbed line-by-line (not blanked): the targeted
 // secret is removed while the rest of the evidence survives. These tests assert
 // the not-contains-secret invariant per redaction category.

--- a/zap-kb/internal/output/forgejo/forgejo_test.go
+++ b/zap-kb/internal/output/forgejo/forgejo_test.go
@@ -593,6 +593,186 @@ func TestExportWiki_RewritesLinks(t *testing.T) {
 	}
 }
 
+// WS05: Forgejo does not render Obsidian [[wikilinks]]; any wikilink whose
+// target is not a published page must be degraded to plain text, never pushed
+// as literal [[..]] syntax.
+func TestExportWiki_NoLiteralWikilinkPublished(t *testing.T) {
+	vault := t.TempDir()
+	os.WriteFile(filepath.Join(vault, "INDEX.md"),
+		[]byte("see [[findings/fin-1.md|F1]] and [[scans/missing.md|old scan]]"), 0o644)
+	os.MkdirAll(filepath.Join(vault, "findings"), 0o755)
+	os.WriteFile(filepath.Join(vault, "findings", "fin-1.md"), []byte("# F1"), 0o644)
+
+	var mu sync.Mutex
+	published := map[string]string{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/repos/acme/kb":
+			json.NewEncoder(w).Encode(map[string]any{"has_wiki": true, "wiki_branch": "main"})
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/wiki/pages"):
+			json.NewEncoder(w).Encode([]map[string]any{})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/wiki/new"):
+			body, _ := io.ReadAll(r.Body)
+			var p map[string]string
+			json.Unmarshal(body, &p)
+			dec, _ := base64.StdEncoding.DecodeString(p["content_base64"])
+			mu.Lock()
+			published[p["title"]] = string(dec)
+			mu.Unlock()
+			w.WriteHeader(http.StatusCreated)
+			w.Write([]byte("{}"))
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+
+	if _, err := ExportWiki(context.Background(), vault, WikiOptions{BaseURL: srv.URL, Token: "t", Owner: "acme", Repo: "kb"}); err != nil {
+		t.Fatalf("ExportWiki: %v", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	home := published["Home"]
+	if strings.Contains(home, "[[") {
+		t.Fatalf("literal wikilink syntax published:\n%s", home)
+	}
+	if !strings.Contains(home, "[F1](Findings%2Ffin-1)") {
+		t.Fatalf("resolved wikilink not rewritten:\n%s", home)
+	}
+	if !strings.Contains(home, "old scan") || strings.Contains(home, "missing.md") {
+		t.Fatalf("unresolved wikilink should degrade to its alias text:\n%s", home)
+	}
+}
+
+// WS06: the second pass must repair links whose server-issued sub_url differs
+// from client-side url.PathEscape — the only authoritative addressing for
+// hierarchical page names on servers with a divergent escaping scheme.
+func TestExportWiki_SecondPassRepairsLinksWithServerSubURLs(t *testing.T) {
+	vault := t.TempDir()
+	os.WriteFile(filepath.Join(vault, "INDEX.md"), []byte("see [[findings/fin-1.md|F1]]"), 0o644)
+	os.MkdirAll(filepath.Join(vault, "findings"), 0o755)
+	os.WriteFile(filepath.Join(vault, "findings", "fin-1.md"), []byte("# F1"), 0o644)
+
+	var mu sync.Mutex
+	var listCalls int
+	patched := map[string]string{} // sub_url -> decoded content
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/repos/acme/kb":
+			json.NewEncoder(w).Encode(map[string]any{"has_wiki": true, "wiki_branch": "main"})
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/wiki/pages"):
+			mu.Lock()
+			listCalls++
+			first := listCalls == 1
+			mu.Unlock()
+			if first {
+				// Pre-publish listing: nothing exists yet.
+				json.NewEncoder(w).Encode([]map[string]any{})
+				return
+			}
+			// Post-publish listing: the server escapes "Findings/fin-1" with
+			// its own scheme that PathEscape cannot reproduce.
+			json.NewEncoder(w).Encode([]map[string]any{
+				{"title": "Home", "sub_url": "Home"},
+				{"title": "Findings/fin-1", "sub_url": "Findings%2Ffin-1.-"},
+			})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/wiki/new"):
+			w.WriteHeader(http.StatusCreated)
+			w.Write([]byte("{}"))
+		case r.Method == http.MethodPatch && strings.Contains(r.URL.Path, "/wiki/page/"):
+			body, _ := io.ReadAll(r.Body)
+			var p map[string]string
+			json.Unmarshal(body, &p)
+			dec, _ := base64.StdEncoding.DecodeString(p["content_base64"])
+			sub := strings.TrimPrefix(r.RequestURI, "/api/v1/repos/acme/kb/wiki/page/")
+			mu.Lock()
+			patched[sub] = string(dec)
+			mu.Unlock()
+			w.Write([]byte("{}"))
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+
+	sum, err := ExportWiki(context.Background(), vault, WikiOptions{BaseURL: srv.URL, Token: "t", Owner: "acme", Repo: "kb"})
+	if err != nil {
+		t.Fatalf("ExportWiki: %v", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if sum.LinkFixes != 1 {
+		t.Fatalf("LinkFixes = %d, want 1 (only Home links to the quirky page)", sum.LinkFixes)
+	}
+	home, ok := patched["Home"]
+	if !ok {
+		t.Fatalf("Home was not re-PATCHed; patched = %v", patched)
+	}
+	if !strings.Contains(home, "](Findings%2Ffin-1.-)") {
+		t.Fatalf("repaired Home must use the server sub_url:\n%s", home)
+	}
+	if _, ok := patched["Findings%2Ffin-1.-"]; ok {
+		t.Fatalf("fin-1 has no internal links and must not be re-PATCHed")
+	}
+}
+
+// WS07 (A3 for link repair): on a steady-state re-publish against a server
+// whose sub_url escaping differs from url.PathEscape, pass 1 must render with
+// the known sub_urls so every page compares equal to the remote and is
+// skipped — no PATCH, no wiki git churn from the repair pass.
+func TestExportWiki_RepublishWithQuirkySubURLsIsNoOp(t *testing.T) {
+	vault := t.TempDir()
+	os.WriteFile(filepath.Join(vault, "INDEX.md"), []byte("see [[findings/fin-1.md|F1]]"), 0o644)
+	os.MkdirAll(filepath.Join(vault, "findings"), 0o755)
+	os.WriteFile(filepath.Join(vault, "findings", "fin-1.md"), []byte("# F1"), 0o644)
+
+	// Remote state after a previous publish + repair: Home already links via
+	// the server's quirky sub_url.
+	remote := map[string]string{
+		"Home":               "see [F1](Findings%2Ffin-1.-)",
+		"Findings%2Ffin-1.-": "# F1",
+	}
+	var mu sync.Mutex
+	var writes int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/repos/acme/kb":
+			json.NewEncoder(w).Encode(map[string]any{"has_wiki": true, "wiki_branch": "main"})
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/wiki/pages"):
+			json.NewEncoder(w).Encode([]map[string]any{
+				{"title": "Home", "sub_url": "Home"},
+				{"title": "Findings/fin-1", "sub_url": "Findings%2Ffin-1.-"},
+			})
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/wiki/page/"):
+			sub := strings.TrimPrefix(r.RequestURI, "/api/v1/repos/acme/kb/wiki/page/")
+			mu.Lock()
+			content := remote[sub]
+			mu.Unlock()
+			json.NewEncoder(w).Encode(map[string]string{
+				"content_base64": base64.StdEncoding.EncodeToString([]byte(content)),
+			})
+		case r.Method == http.MethodPost || r.Method == http.MethodPatch:
+			atomic.AddInt32(&writes, 1)
+			w.Write([]byte("{}"))
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+
+	sum, err := ExportWiki(context.Background(), vault, WikiOptions{BaseURL: srv.URL, Token: "t", Owner: "acme", Repo: "kb"})
+	if err != nil {
+		t.Fatalf("ExportWiki: %v", err)
+	}
+	if sum.Skipped != 2 || sum.Updated != 0 || sum.Created != 0 || sum.LinkFixes != 0 {
+		t.Fatalf("created=%d updated=%d skipped=%d link_fixes=%d, want 0/0/2/0",
+			sum.Created, sum.Updated, sum.Skipped, sum.LinkFixes)
+	}
+	if n := atomic.LoadInt32(&writes); n != 0 {
+		t.Fatalf("steady-state re-publish performed %d write(s); link repair must not churn the wiki", n)
+	}
+}
+
 // WS04: with -forgejo-wiki-prune, KB-owned entity pages absent from the publish
 // are deleted; non-entity pages (Home) are never touched.
 func TestExportWiki_PruneDeletesStaleEntityPages(t *testing.T) {

--- a/zap-kb/internal/output/forgejo/wiki.go
+++ b/zap-kb/internal/output/forgejo/wiki.go
@@ -37,6 +37,10 @@ type WikiSummary struct {
 	Skipped int
 	Errors  int
 	Pruned  int
+	// LinkFixes counts pages re-PATCHed by the second pass because the
+	// server-issued sub_url for a linked page differed from the client-side
+	// escaping used on first publish.
+	LinkFixes int
 }
 
 // topLevelWikiPages maps known vault files to friendly wiki page names. INDEX.md
@@ -55,6 +59,11 @@ var topLevelWikiPages = []struct {
 	{"TRIAGE-GUIDE.md", "Triage Workflow Guide"},
 	{"EXECUTIVE-SUMMARY.md", "Executive Summary"},
 	{"latest-scan.md", "Latest Scan"},
+	// Section pages split out of INDEX — Home's quick-navigation links target
+	// these, so omitting them leaves dead links on the wiki landing page.
+	{"issues.md", "Issues"},
+	{"occurrences.md", "Occurrences"},
+	{"rules.md", "Rules"},
 }
 
 // wikiSubdirs are the entity directories nested as wiki subpages. Slashes in the
@@ -62,10 +71,18 @@ var topLevelWikiPages = []struct {
 var wikiSubdirs = []string{"definitions", "findings", "occurrences"}
 
 // ExportWiki walks the generated Obsidian vault at vaultRoot and upserts each
-// markdown file as a Forgejo wiki page. Because Forgejo renders markdown (and
-// [[wikilinks]]) natively, the vault content is pushed verbatim (frontmatter
-// stripped) — no XHTML conversion. Pages are upserted in parallel up to
-// opts.Concurrency.
+// markdown file as a Forgejo wiki page (frontmatter stripped — no XHTML
+// conversion). Forgejo renders plain markdown but NOT Obsidian [[wikilinks]],
+// so internal links are rewritten to standard markdown links between wiki
+// pages (see rewriteVaultLinks). Publishing is two-pass: pages are upserted
+// with link targets taken from the pre-publish listing's server-issued
+// sub_urls (client-side escaping only for pages that don't exist yet), then
+// the page list is re-fetched and any page whose links differ under the
+// post-publish sub_urls is PATCHed — the server's page-name escaping is the
+// only authoritative source for addressing hierarchical titles
+// ("Findings/fin-1"), and rendering with known sub_urls up front keeps
+// steady-state re-publishes byte-identical (skipped, no git churn). Pages are
+// upserted in parallel up to opts.Concurrency.
 func ExportWiki(ctx context.Context, vaultRoot string, opts WikiOptions) (WikiSummary, error) {
 	if strings.TrimSpace(opts.BaseURL) == "" || strings.TrimSpace(opts.Token) == "" ||
 		strings.TrimSpace(opts.Owner) == "" || strings.TrimSpace(opts.Repo) == "" {
@@ -132,8 +149,10 @@ func ExportWiki(ctx context.Context, vaultRoot string, opts WikiOptions) (WikiSu
 	}
 	sort.Slice(pages, func(i, j int) bool { return pages[i].name < pages[j].name })
 
-	// Snapshot the set of page names published this run BEFORE the canary
-	// consumes pages[0] — used by the prune pass to spare current pages.
+	// Snapshot the full page set BEFORE the canary consumes pages[0]: the prune
+	// pass needs the published names, and the link-repair pass revisits every
+	// page.
+	allPages := append([]page(nil), pages...)
 	publishedNames := make(map[string]bool, len(pages))
 	for _, p := range pages {
 		publishedNames[p.name] = true
@@ -165,6 +184,19 @@ func ExportWiki(ctx context.Context, vaultRoot string, opts WikiOptions) (WikiSu
 		return summary, fmt.Errorf("forgejo wiki: list pages: %w", err)
 	}
 
+	// Render links with the server-issued sub_urls already known from the
+	// pre-publish listing, falling back to client-side escaping for pages that
+	// do not exist yet. On a steady-state re-publish every link target is a
+	// known sub_url, so rendered content matches the remote byte-for-byte and
+	// the upsert skips — using PathEscape here would diff against the repaired
+	// remote content and churn the wiki's git history on every run.
+	linkFor := func(name string) string {
+		if su := existing[name]; su != "" {
+			return su
+		}
+		return escapePageName(name)
+	}
+
 	// Canary: publish the first page serially. A server hit by the Gitea 1.22
 	// wiki_branch bug fails EVERY write the same way — one descriptive hard
 	// error beats N identical per-page 404s, and aborting here avoids
@@ -177,7 +209,7 @@ func ExportWiki(ctx context.Context, vaultRoot string, opts WikiOptions) (WikiSu
 			summary.Errors++
 			fmt.Printf("[forgejo wiki] error reading %s: %v\n", p.path, err)
 		} else {
-			content = rewriteVaultLinks(content, p.relDir, pageNames)
+			content = rewriteVaultLinks(content, p.relDir, pageNames, linkFor)
 			action, err := c.upsertWikiPage(ctx, p.name, content, msg, existing)
 			switch {
 			case isWikiBranchBug(err):
@@ -210,7 +242,7 @@ func ExportWiki(ctx context.Context, vaultRoot string, opts WikiOptions) (WikiSu
 				fmt.Printf("[forgejo wiki] error reading %s: %v\n", p.path, err)
 				return
 			}
-			content = rewriteVaultLinks(content, p.relDir, pageNames)
+			content = rewriteVaultLinks(content, p.relDir, pageNames, linkFor)
 			action, err := c.upsertWikiPage(ctx, p.name, content, msg, existing)
 			mu.Lock()
 			defer mu.Unlock()
@@ -228,6 +260,46 @@ func ExportWiki(ctx context.Context, vaultRoot string, opts WikiOptions) (WikiSu
 		}(p)
 	}
 	wg.Wait()
+
+	// Pass 2: link repair. Re-list to obtain server-issued sub_urls for the
+	// pages just created, re-render every page's links against those tokens,
+	// and PATCH the pages whose content changed. On servers whose page-name
+	// escaping matches url.PathEscape this finds nothing and costs one listing
+	// call; on servers with a divergent scheme it is the only way hierarchical
+	// cross-links ("Findings/fin-1") resolve instead of 404ing.
+	subURLs, lerr := c.listWikiPages(ctx)
+	if lerr != nil {
+		summary.Errors++
+		fmt.Printf("[forgejo wiki] error listing pages for link repair (links may use client-side escaping): %v\n", lerr)
+	} else {
+		linkForSub := func(name string) string {
+			if su := subURLs[name]; su != "" {
+				return su
+			}
+			return escapePageName(name)
+		}
+		for _, p := range allPages {
+			su := subURLs[p.name]
+			if su == "" {
+				continue // page never landed; already counted as an error
+			}
+			raw, rerr := readVaultMarkdown(p.path)
+			if rerr != nil {
+				continue // unreadable file was already counted in pass 1
+			}
+			pass1 := rewriteVaultLinks(raw, p.relDir, pageNames, linkFor)
+			pass2 := rewriteVaultLinks(raw, p.relDir, pageNames, linkForSub)
+			if pass2 == pass1 {
+				continue
+			}
+			if perr := c.patchWikiPage(ctx, su, p.name, pass2, msg); perr != nil {
+				summary.Errors++
+				fmt.Printf("[forgejo wiki] error repairing links on %q: %v\n", p.name, perr)
+				continue
+			}
+			summary.LinkFixes++
+		}
+	}
 
 	// Prune stale KB-owned entity pages. Only the three entity prefixes are
 	// KB-managed by convention; Home and any analyst-authored page are never
@@ -355,6 +427,13 @@ func (c *client) upsertWikiPage(ctx context.Context, name, content, message stri
 			return "skipped", nil
 		}
 	}
+	if exists {
+		if err := c.patchWikiPage(ctx, subURL, name, content, message); err != nil {
+			return "", err
+		}
+		return "updated", nil
+	}
+
 	body, err := json.Marshal(map[string]string{
 		"title":          name,
 		"content_base64": base64.StdEncoding.EncodeToString([]byte(content)),
@@ -363,22 +442,6 @@ func (c *client) upsertWikiPage(ctx context.Context, name, content, message stri
 	if err != nil {
 		return "", err
 	}
-
-	if exists {
-		// sub_url is already escaped by the server — append verbatim.
-		u := c.repoAPI() + "/wiki/page/" + subURL
-		req, err := c.newRequest(ctx, http.MethodPatch, u, body)
-		if err != nil {
-			return "", err
-		}
-		resp, err := synccore.DoWithRetry(c.http, req, 3)
-		if err != nil {
-			return "", err
-		}
-		drain(resp)
-		return "updated", nil
-	}
-
 	req, err := c.newRequest(ctx, http.MethodPost, c.repoAPI()+"/wiki/new", body)
 	if err != nil {
 		return "", err
@@ -389,6 +452,29 @@ func (c *client) upsertWikiPage(ctx context.Context, name, content, message stri
 	}
 	drain(resp)
 	return "created", nil
+}
+
+// patchWikiPage overwrites a wiki page's content via its server-issued
+// sub_url (already escaped — appended verbatim).
+func (c *client) patchWikiPage(ctx context.Context, subURL, title, content, message string) error {
+	body, err := json.Marshal(map[string]string{
+		"title":          title,
+		"content_base64": base64.StdEncoding.EncodeToString([]byte(content)),
+		"message":        message,
+	})
+	if err != nil {
+		return err
+	}
+	req, err := c.newRequest(ctx, http.MethodPatch, c.repoAPI()+"/wiki/page/"+subURL, body)
+	if err != nil {
+		return err
+	}
+	resp, err := synccore.DoWithRetry(c.http, req, 3)
+	if err != nil {
+		return err
+	}
+	drain(resp)
+	return nil
 }
 
 // getWikiPageBySubURL fetches a wiki page's decoded content via its

--- a/zap-kb/internal/output/forgejo/wiki.go
+++ b/zap-kb/internal/output/forgejo/wiki.go
@@ -60,8 +60,10 @@ var topLevelWikiPages = []struct {
 	{"EXECUTIVE-SUMMARY.md", "Executive Summary"},
 	{"latest-scan.md", "Latest Scan"},
 	// Section pages split out of INDEX — Home's quick-navigation links target
-	// these, so omitting them leaves dead links on the wiki landing page.
-	{"issues.md", "Issues"},
+	// these, so omitting them leaves dead links on the wiki landing page. The
+	// findings section file is issues.md (historical name) but the Forgejo vault
+	// titles the page "Findings" to avoid colliding with Forgejo's Issues tab.
+	{"issues.md", "Findings"},
 	{"occurrences.md", "Occurrences"},
 	{"rules.md", "Rules"},
 }

--- a/zap-kb/internal/output/forgejo/wikilinks.go
+++ b/zap-kb/internal/output/forgejo/wikilinks.go
@@ -10,30 +10,37 @@ import (
 // Vault markdown links target FILES (relative paths, often with .md); the
 // published wiki addresses PAGES (renamed, hierarchical, no extension).
 // rewriteVaultLinks converts every internal link whose target resolves to a
-// published page into a standard markdown link to that page; anything that
-// does not resolve (external URLs, images, unpublished files) is left
-// untouched, so a partial vault never produces broken rewrites.
+// published page into a standard markdown link to that page. Links that do
+// NOT resolve are degraded to their plain display text: Forgejo does not
+// render Obsidian [[wikilinks]], and a markdown link to an unpublished .md
+// file 404s on the wiki — literal link syntax or a dead link would both read
+// as breakage to analysts. External URLs and embeds are left untouched.
 //
-// Live-server caveat: url.PathEscape produces "Findings%2Ffin-1"-style targets.
-// The Forgejo/Gitea web UI is expected to resolve these against
-// /{owner}/{repo}/wiki/, but server-side sub_url generation has known quirks
-// (see the comment above listWikiPages). If escaped hierarchical links 404 on a
-// real server, the fallback is a two-pass publish (upsert, re-list to obtain
-// server sub_urls, rewrite with those, PATCH changed pages) — file an issue
-// rather than implementing it speculatively.
+// linkFor maps a wiki page name to the URL token used in the rewritten link.
+// Pass escapePageName for a best-effort first publish; pass a server-issued
+// sub_url lookup for the repair pass (see ExportWiki) — server-side page-name
+// escaping is not guaranteed to match url.PathEscape, so only the sub_url is
+// authoritative.
 
 var (
-	// [[target]] or [[target|alias]] — Obsidian wikilink.
-	wikilinkRe = regexp.MustCompile(`\[\[([^\]|]+)(?:\|([^\]]+))?\]\]`)
+	// [[target]] or [[target|alias]] — Obsidian wikilink. A leading "!" marks
+	// an embed, which is preserved verbatim.
+	wikilinkRe = regexp.MustCompile(`(!?)\[\[([^\]|]+)(?:\|([^\]]+))?\]\]`)
 	// [text](target.md) or [text](target.md#frag) — markdown link to a vault file.
 	mdLinkRe = regexp.MustCompile(`(\[[^\]]*\])\(([^)#\s]+\.md)(#[^)\s]*)?\)`)
 )
 
+// escapePageName is the default linkFor: client-side escaping of the page
+// name, matching what the Forgejo web UI uses for same-wiki relative links.
+func escapePageName(name string) string {
+	return url.PathEscape(name)
+}
+
 // rewriteVaultLinks rewrites the internal links of one vault file's content.
 // relDir is the file's directory relative to the vault root ("." for top-level
 // files); pageNames maps vault-relative file paths to wiki page names (see
-// ExportWiki).
-func rewriteVaultLinks(content, relDir string, pageNames map[string]string) string {
+// ExportWiki); linkFor maps a resolved page name to its link target.
+func rewriteVaultLinks(content, relDir string, pageNames map[string]string, linkFor func(string) string) string {
 	resolve := func(target string) (string, bool) {
 		target = strings.TrimSpace(target)
 		if target == "" || strings.Contains(target, "://") {
@@ -46,11 +53,11 @@ func rewriteVaultLinks(content, relDir string, pageNames map[string]string) stri
 		// accept whichever names a published page. Wikilinks may omit ".md".
 		for _, cand := range []string{path.Clean(target), path.Clean(path.Join(relDir, target))} {
 			if name, ok := pageNames[cand]; ok {
-				return url.PathEscape(name), true
+				return linkFor(name), true
 			}
 			if !strings.HasSuffix(cand, ".md") {
 				if name, ok := pageNames[cand+".md"]; ok {
-					return url.PathEscape(name), true
+					return linkFor(name), true
 				}
 			}
 		}
@@ -59,25 +66,35 @@ func rewriteVaultLinks(content, relDir string, pageNames map[string]string) stri
 
 	out := wikilinkRe.ReplaceAllStringFunc(content, func(m string) string {
 		sub := wikilinkRe.FindStringSubmatch(m)
-		target, frag := sub[1], ""
+		if sub[1] == "!" {
+			return m // embed — not a navigation link
+		}
+		target, frag := sub[2], ""
 		if i := strings.Index(target, "#"); i >= 0 {
 			target, frag = target[:i], target[i:]
 		}
-		esc, ok := resolve(target)
-		if !ok {
-			return m
-		}
-		alias := strings.TrimSpace(sub[2])
+		alias := strings.TrimSpace(sub[3])
 		if alias == "" {
 			alias = strings.TrimSuffix(path.Base(strings.TrimSpace(target)), ".md")
 		}
+		esc, ok := resolve(target)
+		if !ok {
+			return alias // unpublished target — plain text beats literal [[..]]
+		}
+		// Square brackets in the alias would nest link syntax in the rendered
+		// markdown ("[a [b](x)]") — swap for parentheses.
+		alias = strings.NewReplacer("[", "(", "]", ")").Replace(alias)
 		return "[" + alias + "](" + esc + frag + ")"
 	})
 	return mdLinkRe.ReplaceAllStringFunc(out, func(m string) string {
 		sub := mdLinkRe.FindStringSubmatch(m)
+		if strings.Contains(sub[2], "://") {
+			return m // external URL that happens to end in .md
+		}
 		esc, ok := resolve(sub[2])
 		if !ok {
-			return m
+			// Unpublished vault file — degrade to the display text.
+			return strings.TrimSuffix(strings.TrimPrefix(sub[1], "["), "]")
 		}
 		return sub[1] + "(" + esc + sub[3] + ")"
 	})

--- a/zap-kb/internal/output/forgejo/wikilinks_test.go
+++ b/zap-kb/internal/output/forgejo/wikilinks_test.go
@@ -28,10 +28,16 @@ func TestRewriteVaultLinks_Table(t *testing.T) {
 		{"[[tuning-candidates|Tuning Candidates]]", ".", "[Tuning Candidates](Tuning%20Candidates)"},
 		{"[[findings/fin-1.md]]", ".", "[fin-1](Findings%2Ffin-1)"},
 		{"[ext](https://example.com/a.md)", ".", "[ext](https://example.com/a.md)"},
-		{"[gone](missing.md)", ".", "[gone](missing.md)"},
+		// Unpublished targets degrade to plain text: Forgejo renders neither
+		// literal [[wikilinks]] nor links to pages that don't exist.
+		{"[gone](missing.md)", ".", "gone"},
+		{"[[missing.md|Gone]]", ".", "Gone"},
+		{"[[missing.md]]", ".", "missing"},
+		// Embeds are not navigation links — leave them alone.
+		{"![[missing.png]]", ".", "![[missing.png]]"},
 	}
 	for _, c := range cases {
-		got := rewriteVaultLinks(c.content, c.relDir, pn)
+		got := rewriteVaultLinks(c.content, c.relDir, pn, escapePageName)
 		if got != c.want {
 			t.Errorf("rewriteVaultLinks(%q, relDir=%q) = %q, want %q", c.content, c.relDir, got, c.want)
 		}
@@ -41,9 +47,49 @@ func TestRewriteVaultLinks_Table(t *testing.T) {
 func TestRewriteVaultLinks_Idempotent(t *testing.T) {
 	pn := wikiFixture()
 	in := "[[definitions/def-1.md|XSS]]"
-	once := rewriteVaultLinks(in, ".", pn)
-	twice := rewriteVaultLinks(once, ".", pn)
+	once := rewriteVaultLinks(in, ".", pn, escapePageName)
+	twice := rewriteVaultLinks(once, ".", pn, escapePageName)
 	if once != twice {
 		t.Fatalf("not idempotent: once=%q twice=%q", once, twice)
+	}
+}
+
+// A wikilink inside a markdown table cell must never survive rewriting: the
+// raw "|" inside [[link|alias]] would split the cell in any CommonMark
+// renderer. Resolved links become standard md links; unresolved become text.
+func TestRewriteVaultLinks_NoWikilinkSurvives(t *testing.T) {
+	pn := wikiFixture()
+	in := "| [[findings/fin-1.md|F1]] | x |\n| [[missing.md|M]] | y |\n"
+	got := rewriteVaultLinks(in, ".", pn, escapePageName)
+	if want := "| [F1](Findings%2Ffin-1) | x |\n| M | y |\n"; got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+// Square brackets inside a wikilink alias must not survive into the rendered
+// markdown link text — "[GET /search [q](url)]" nests a bogus inner link and
+// only the "[q]" fragment renders as clickable.
+func TestRewriteVaultLinks_BracketsInAliasNeutralized(t *testing.T) {
+	pn := wikiFixture()
+	got := rewriteVaultLinks("[[findings/fin-1.md|GET /search [q)]]", ".", pn, escapePageName)
+	if want := "[GET /search (q)](Findings%2Ffin-1)"; got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+// The repair pass swaps the link target source: server-issued sub_urls take
+// precedence over client-side escaping when provided.
+func TestRewriteVaultLinks_LinkForOverride(t *testing.T) {
+	pn := wikiFixture()
+	sub := map[string]string{"Findings/fin-1": "Findings%2Ffin-1.-"}
+	linkFor := func(name string) string {
+		if s := sub[name]; s != "" {
+			return s
+		}
+		return escapePageName(name)
+	}
+	got := rewriteVaultLinks("[[findings/fin-1.md|fin-1]]", ".", pn, linkFor)
+	if want := "[fin-1](Findings%2Ffin-1.-)"; got != want {
+		t.Fatalf("got %q, want %q", got, want)
 	}
 }

--- a/zap-kb/internal/output/obsidian/legend.go
+++ b/zap-kb/internal/output/obsidian/legend.go
@@ -41,32 +41,36 @@ Findings and occurrences use short aliases for display in tables and links.
 _D1 and DZ prefixes appear when rule initials conflict or are unregistered — file a PR to expand this legend._
 `
 
-const triageGuideContent = `# Triage Workflow Guide
+// triageGuideContent renders the static analyst workflow guide for the
+// configured tracker and evidence surface (Jira/Confluence by default, e.g.
+// Forgejo/wiki for the Forgejo sink).
+func triageGuideContent(tracker, surface string) string {
+	return fmt.Sprintf(`# Triage Workflow Guide
 
 ## Workflow source of truth
 
-Jira is the source of truth for analyst workflow state, ownership, and closure.
+%[1]s is the source of truth for analyst workflow state, ownership, and closure.
 The KB is the evidence and reporting surface. It lists linked analyst cases and
 keeps KB lifecycle fields only as historical scan context.
 
 ## How to work the finding
 
-1. Review the finding and occurrence evidence in Confluence.
-2. Work the analyst case in Jira.
-3. Use the Jira status, assignee, comments, and linked work items for triage state.
-4. Use ` + "`case-ticket`" + ` for low/info findings that should still open an analyst case.
-5. Use ` + "`tune-scan`" + ` when a recurring false positive needs scan-tuning follow-up.
+1. Review the finding and occurrence evidence in %[2]s.
+2. Work the analyst case in %[1]s.
+3. Use the %[1]s status, assignee, comments, and linked work items for triage state.
+4. Use `+"`case-ticket`"+` for low/info findings that should still open an analyst case.
+5. Use `+"`tune-scan`"+` when a recurring false positive needs scan-tuning follow-up.
 6. Do not close work by editing generated KB-local status fields.
 
 ## Bulk triage
 
 1. Open the definition page (e.g., CDM).
 2. Review the **False Positive Conditions** section.
-3. For each affected finding, open the linked analyst case and update Jira.
+3. For each affected finding, open the linked analyst case and update %[1]s.
 
 ## Escalation
 
-- Use the analyst Jira project for case management and triage.
+- Use the analyst %[1]s project for case management and triage.
 - Keep analyst case IDs linked from the finding or occurrence.
 - If remediation is needed, track the downstream team ticket as a linked reference rather than replacing the analyst case.
 
@@ -74,8 +78,18 @@ keeps KB lifecycle fields only as historical scan context.
 
 Generated pages may show a KB lifecycle snapshot from imported or historical data.
 Treat it as context only unless the deployment is intentionally running a
-Confluence-driven workflow.
-`
+workflow driven from %[2]s.
+`, tracker, surface)
+}
+
+// workflowSurface names the evidence-rendering surface paired with the
+// tracker: Confluence for the default Jira wording, the repo wiki otherwise.
+func (o Options) workflowSurface() string {
+	if o.trackerName() == "Jira" {
+		return "Confluence"
+	}
+	return "the KB wiki"
+}
 
 // writeLegend writes LEGEND.md (static content — no entities data needed).
 func writeLegend(root string) error {
@@ -83,8 +97,9 @@ func writeLegend(root string) error {
 }
 
 // writeTriageGuide writes TRIAGE-GUIDE.md (static workflow guide for analysts).
-func writeTriageGuide(root string) error {
-	return os.WriteFile(filepath.Join(root, "TRIAGE-GUIDE.md"), []byte(triageGuideContent), 0o644)
+func writeTriageGuide(root string, opts Options) error {
+	content := triageGuideContent(opts.trackerName(), opts.workflowSurface())
+	return os.WriteFile(filepath.Join(root, "TRIAGE-GUIDE.md"), []byte(content), 0o644)
 }
 
 // writeByScan writes by-scan.md, grouping occurrences by ScanLabel.
@@ -356,8 +371,9 @@ func writeExecutiveSummary(root string, ef entities.EntitiesFile, opts Options, 
 		fmt.Fprintf(&b, "_Generated: %s_\n\n", ts)
 	}
 
+	tracker := opts.trackerName()
 	b.WriteString("## Risk posture\n\n")
-	b.WriteString("_Counts are KB evidence totals, not Jira workflow state. Jira remains the source of truth for open/done ownership and closure._\n\n")
+	fmt.Fprintf(&b, "_Counts are KB evidence totals, not %[1]s workflow state. %[1]s remains the source of truth for open/done ownership and closure._\n\n", tracker)
 	b.WriteString("| Severity | Findings | Occurrences |\n")
 	b.WriteString("|---|---|---|\n")
 	for _, r := range sevRows {
@@ -379,7 +395,7 @@ func writeExecutiveSummary(root string, ef entities.EntitiesFile, opts Options, 
 	}
 
 	b.WriteString("## Recommended immediate actions\n\n")
-	b.WriteString("_Top High-severity finding groups to review against Jira workflow state:_\n\n")
+	fmt.Fprintf(&b, "_Top High-severity finding groups to review against %s workflow state:_\n\n", tracker)
 	if len(actions) == 0 {
 		b.WriteString("_No High-severity findings._\n\n")
 	} else {

--- a/zap-kb/internal/output/obsidian/legend.go
+++ b/zap-kb/internal/output/obsidian/legend.go
@@ -332,7 +332,7 @@ func writeExecutiveSummary(root string, ef entities.EntitiesFile, opts Options, 
 			Title:     title,
 			Remedy:    remedy,
 			FindCount: len(fids),
-			FindLink:  "INDEX.md#issues",
+			FindLink:  "INDEX.md#" + opts.sectionAnchor(),
 		})
 	}
 	// Sort by find count desc, then title asc.

--- a/zap-kb/internal/output/obsidian/obsidian.go
+++ b/zap-kb/internal/output/obsidian/obsidian.go
@@ -72,6 +72,10 @@ func WriteVault(root string, ef entities.EntitiesFile, opts Options) error {
 	// Tracker display name used by workflow prose ("Jira" by default).
 	tracker := opts.trackerName()
 	noCase := "No " + tracker + " case"
+	// KB-finding label + section anchor (Issue/Issues for Jira, Finding/Findings
+	// otherwise — Forgejo's own Issues tab collides with the word).
+	findNounS, findNounP := opts.findingNoun()
+	findAnchor := opts.sectionAnchor()
 
 	// Optionally carry forward analyst status and timestamps from existing
 	// occurrence files BEFORE we clear the directories. Raw scanner publishes
@@ -585,7 +589,7 @@ func WriteVault(root string, ef entities.EntitiesFile, opts Options) error {
 				findingsBySeverity[sevKey] = append(findingsBySeverity[sevKey], f)
 			}
 
-			b.WriteString("## Issues\n\n")
+			fmt.Fprintf(&b, "## %s\n\n", findNounP)
 			severityOrder := []string{"high", "medium", "low", "info"}
 			for _, sev := range severityOrder {
 				group := findingsBySeverity[sev]
@@ -649,7 +653,7 @@ func WriteVault(root string, ef entities.EntitiesFile, opts Options) error {
 					}
 				}
 				if limit < len(group) {
-					fmt.Fprintf(&b, "- _%d additional findings — [[../INDEX.md#issues|see full list]]_\n", len(group)-limit)
+					fmt.Fprintf(&b, "- _%d additional findings — [[../INDEX.md#%s|see full list]]_\n", len(group)-limit, findAnchor)
 				}
 				b.WriteString("\n")
 			}
@@ -735,7 +739,7 @@ func WriteVault(root string, ef entities.EntitiesFile, opts Options) error {
 		addStatusToYAMLStrAny(kv, "status.", sc)
 		writeYAML(&b, kv)
 
-		fmt.Fprintf(&b, "# Issue %s — %s\n\n", f.FindingID, alias)
+		fmt.Fprintf(&b, "# %s %s — %s\n\n", findNounS, f.FindingID, alias)
 		// Severity callout
 		sevTxt, _ := deriveSeverity(f.Risk, f.RiskCode)
 		b.WriteString(calloutForSeverity(sevTxt, fmt.Sprintf("Risk: %s (%s) — Confidence: %s", f.Risk, f.RiskCode, f.Confidence)))
@@ -1132,7 +1136,7 @@ func WriteVault(root string, ef entities.EntitiesFile, opts Options) error {
 		} else {
 			fmt.Fprintf(&b, "- Definition: %s\n", o.DefinitionID)
 		}
-		fmt.Fprintf(&b, "- Issue: [[%s|%s]]\n\n", filepath.ToSlash(filepath.Join("occurrences", "..", "findings", o.FindingID+".md")), o.FindingID)
+		fmt.Fprintf(&b, "- %s: [[%s|%s]]\n\n", findNounS, filepath.ToSlash(filepath.Join("occurrences", "..", "findings", o.FindingID+".md")), o.FindingID)
 
 		fmt.Fprintf(&b, "**Endpoint:** %s %s\n\n", o.Method, o.URL)
 
@@ -1348,7 +1352,7 @@ func WriteVault(root string, ef entities.EntitiesFile, opts Options) error {
 				sevParts = append(sevParts, fmt.Sprintf("%s: %d", entry.Label, c))
 			}
 		}
-		summaryLine := fmt.Sprintf("Scan: %s (domain: %s) | Issues: %d | Occurrences: %d", scanName, domainLabel, totalIssues, totalOcc)
+		summaryLine := fmt.Sprintf("Scan: %s (domain: %s) | %s: %d | Occurrences: %d", scanName, domainLabel, findNounP, totalIssues, totalOcc)
 		if len(sevParts) > 0 {
 			summaryLine += " | " + strings.Join(sevParts, " ")
 		}
@@ -1357,7 +1361,7 @@ func WriteVault(root string, ef entities.EntitiesFile, opts Options) error {
 
 		b.WriteString("## Quick navigation\n")
 		b.WriteString("- [Triage board](triage-board.md)\n")
-		b.WriteString("- [Issues](issues.md)\n")
+		fmt.Fprintf(&b, "- [%s](issues.md)\n", findNounP)
 		b.WriteString("- [Occurrences](occurrences.md)\n")
 		b.WriteString("- [Rules](rules.md)\n")
 		b.WriteString("- [By domain](by-domain.md)\n")
@@ -1378,7 +1382,7 @@ func WriteVault(root string, ef entities.EntitiesFile, opts Options) error {
 
 		fmt.Fprintf(&triageSection, "## %s references\n\n", tracker)
 		fmt.Fprintf(&triageSection, "Analyst workflow status comes from %s. The KB lists linked analyst cases and keeps lifecycle status as a historical snapshot only.\n\n", tracker)
-		triageSection.WriteString("| Analyst cases | Issues | Occurrences |\n| --- | --- | --- |\n")
+		fmt.Fprintf(&triageSection, "| Analyst cases | %s | Occurrences |\n| --- | --- | --- |\n", findNounP)
 		for _, bucket := range sortedWorkflowBuckets(trackerIssueCounts, trackerOccurrenceCounts) {
 			fmt.Fprintf(&triageSection, "| %s | %d | %d |\n", escapeTable(bucket), trackerIssueCounts[bucket], trackerOccurrenceCounts[bucket])
 		}
@@ -1437,9 +1441,9 @@ func WriteVault(root string, ef entities.EntitiesFile, opts Options) error {
 
 		// Issues table — operational rules are excluded and shown separately below.
 		if len(issueSummaries) > 0 {
-			b.WriteString("## Issues\n")
+			fmt.Fprintf(&b, "## %s\n", findNounP)
 			b.WriteString("Sorted by severity, then endpoint.\n\n")
-			b.WriteString("| Severity | Issue | Endpoint | Analyst Cases | Occurrences | Rule |\n| --- | --- | --- | --- | --- | --- |\n")
+			fmt.Fprintf(&b, "| Severity | %s | Endpoint | Analyst Cases | Occurrences | Rule |\n| --- | --- | --- | --- | --- | --- |\n", findNounS)
 			allIssues := append([]issueSummary(nil), issueSummaries...)
 			sortIssues(allIssues)
 			for _, is := range allIssues {
@@ -1492,7 +1496,7 @@ func WriteVault(root string, ef entities.EntitiesFile, opts Options) error {
 		// Occurrence table
 		if totalOcc > 0 {
 			b.WriteString("## Occurrences\n\n")
-			b.WriteString("| Occurrence | Endpoint | Param | Severity | Analyst Cases | Issue |\n| --- | --- | --- | --- | --- | --- |\n")
+			fmt.Fprintf(&b, "| Occurrence | Endpoint | Param | Severity | Analyst Cases | %s |\n| --- | --- | --- | --- | --- | --- |\n", findNounS)
 			tmpOccs := make([]entities.Occurrence, len(ef.Occurrences))
 			copy(tmpOccs, ef.Occurrences)
 			sort.Slice(tmpOccs, func(i, j int) bool {
@@ -1690,7 +1694,7 @@ func WriteVault(root string, ef entities.EntitiesFile, opts Options) error {
 		if err := os.WriteFile(index, []byte(indexContent), 0o644); err != nil {
 			return err
 		}
-		if err := writeSectionPage(root, "issues.md", "Issues", extractMarkdownSection(indexContent, "Issues")); err != nil {
+		if err := writeSectionPage(root, "issues.md", findNounP, extractMarkdownSection(indexContent, findNounP)); err != nil {
 			return err
 		}
 		if err := writeSectionPage(root, "occurrences.md", "Occurrences", extractMarkdownSection(indexContent, "Occurrences")); err != nil {
@@ -1840,7 +1844,7 @@ func WriteVault(root string, ef entities.EntitiesFile, opts Options) error {
 				tc.WriteString("Tag a finding with `tune-scan` (YAML `analyst.tags`) when a recurring false positive needs detection-tuning work, or let the recurring-FP heuristic promote it automatically.\n")
 			} else {
 				fmt.Fprintf(&tc, "Total: **%d**\n\n", len(tuningCandidates))
-				tc.WriteString("| Issue | Rule | Endpoint | Scans seen | `tune-scan` | Owner | Tickets |\n")
+				fmt.Fprintf(&tc, "| %s | Rule | Endpoint | Scans seen | `tune-scan` | Owner | Tickets |\n", findNounS)
 				tc.WriteString("| --- | --- | --- | --- | --- | --- | --- |\n")
 				for _, is := range tuningCandidates {
 					ruleTitle := fallbackString(is.RuleTitle, "Rule")
@@ -1889,7 +1893,7 @@ func WriteVault(root string, ef entities.EntitiesFile, opts Options) error {
 			var spot strings.Builder
 			spot.WriteString("# Latest scan spotlight\n\n")
 			spot.WriteString(fmt.Sprintf("Scan: %s\n\n", latestScanLabel))
-			spot.WriteString("| Occurrence | Endpoint | Severity | Analyst Cases | Issue |\n| --- | --- | --- | --- | --- |\n")
+			fmt.Fprintf(&spot, "| Occurrence | Endpoint | Severity | Analyst Cases | %s |\n| --- | --- | --- | --- | --- |\n", findNounS)
 			for _, o := range newestOccs {
 				key := strings.Join([]string{strings.TrimSpace(o.FindingID), strings.TrimSpace(o.URL), strings.TrimSpace(o.Param), strings.TrimSpace(o.Attack)}, "|")
 				if !seenByKey[key] {
@@ -3032,6 +3036,23 @@ func (o Options) trackerName() string {
 		return t
 	}
 	return "Jira"
+}
+
+// findingNoun returns the singular/plural KB-finding label used in generated
+// page text. On the default (Jira) tracker it stays "Issue"/"Issues" so the
+// Confluence path and its anchors are unchanged; on any other tracker (e.g.
+// Forgejo, whose own Issues tab collides with the word) it becomes
+// "Finding"/"Findings". sectionAnchor returns the matching lowercase anchor.
+func (o Options) findingNoun() (singular, plural string) {
+	if o.trackerName() == "Jira" {
+		return "Issue", "Issues"
+	}
+	return "Finding", "Findings"
+}
+
+func (o Options) sectionAnchor() string {
+	_, plural := o.findingNoun()
+	return strings.ToLower(plural)
 }
 
 func formatTicketRefsMarkdown(refs []string, opts Options, placeholder string) string {

--- a/zap-kb/internal/output/obsidian/obsidian.go
+++ b/zap-kb/internal/output/obsidian/obsidian.go
@@ -27,6 +27,14 @@ type Options struct {
 	ZapBaseURL string
 	// JiraBaseURL, when set, turns analyst ticket refs into live Jira browse links.
 	JiraBaseURL string
+	// Tracker names the external issue tracker referenced by generated prose
+	// ("Forgejo" for the Forgejo sink). Empty means "Jira" so existing
+	// Jira/Confluence deployments keep their wording unchanged.
+	Tracker string
+	// TicketURLFn, when non-nil, resolves an analyst ticket ref to a browse
+	// URL before the Jira-key fallback is tried (e.g. Forgejo "owner/repo#42"
+	// refs, which are not Jira keys). Return "" to decline a ref.
+	TicketURLFn func(ref string) string
 	// JiraStatusByKey carries raw Jira workflow statuses fetched at publish time.
 	JiraStatusByKey map[string]string
 	// JiraAssigneeByKey carries Jira assignee display names fetched at publish time.
@@ -60,6 +68,10 @@ func WriteVault(root string, ef entities.EntitiesFile, opts Options) error {
 	defDir := filepath.Join(root, "definitions")
 	findDir := filepath.Join(root, "findings")
 	occDir := filepath.Join(root, "occurrences")
+
+	// Tracker display name used by workflow prose ("Jira" by default).
+	tracker := opts.trackerName()
+	noCase := "No " + tracker + " case"
 
 	// Optionally carry forward analyst status and timestamps from existing
 	// occurrence files BEFORE we clear the directories. Raw scanner publishes
@@ -803,8 +815,12 @@ func WriteVault(root string, ef entities.EntitiesFile, opts Options) error {
 					caption = urlBasename(o.URL)
 				}
 				if strings.TrimSpace(o.Param) != "" {
-					caption += " [" + strings.TrimSpace(o.Param) + "]"
+					// Parentheses, not square brackets: "[q]" inside a link alias
+					// terminates the wikilink early and the rendered markdown nests
+					// a bogus inner link ("[GET /search [q](url)]").
+					caption += " (" + strings.TrimSpace(o.Param) + ")"
 				}
+				caption = linkAliasSafe(caption)
 				ev := strings.TrimSpace(o.Evidence)
 				if ev != "" {
 					ev = truncate(ev, 60)
@@ -878,9 +894,9 @@ func WriteVault(root string, ef entities.EntitiesFile, opts Options) error {
 
 		b.WriteString("## Workflow\n\n")
 		fmt.Fprintf(&b, "- Tags: %s\n", formatListOrPlaceholder(tags, "_None_"))
-		fmt.Fprintf(&b, "- Analyst cases: %s\n", formatTicketRefsMarkdown(tickets, opts.JiraBaseURL, "_None_"))
+		fmt.Fprintf(&b, "- Analyst cases: %s\n", formatTicketRefsMarkdown(tickets, opts, "_None_"))
 		if len(tickets) > 0 {
-			b.WriteString("- Workflow source: Jira analyst case\n")
+			fmt.Fprintf(&b, "- Workflow source: %s analyst case\n", tracker)
 		}
 		fmt.Fprintf(&b, "- KB lifecycle snapshot: %s\n", titleASCII(workflowStatus))
 		if len(owners) > 0 {
@@ -938,10 +954,10 @@ func WriteVault(root string, ef entities.EntitiesFile, opts Options) error {
 
 		b.WriteString("### Quick triage shortcuts\n\n")
 		b.WriteString("- Set `analyst.status` to: open | triaged | fp | accepted | fixed\n")
-		b.WriteString("- Add `case-ticket` to `analyst.tags` to export low/info findings to the analyst Jira project\n")
+		fmt.Fprintf(&b, "- Add `case-ticket` to `analyst.tags` to export low/info findings to the analyst %s project\n", tracker)
 		b.WriteString("- Add ticket IDs under `analyst.ticketRefs` (YAML list)\n")
 		b.WriteString("- Add `tune-scan` to `analyst.tags` when a recurring false positive needs detection tuning follow-up\n")
-		b.WriteString("- Assign Jira cases in Jira; `analyst.owner` is retained only as a KB snapshot field\n\n")
+		fmt.Fprintf(&b, "- Assign %s cases in %s; `analyst.owner` is retained only as a KB snapshot field\n\n", tracker, tracker)
 
 		b.WriteString("### Analyst notebook\n\n")
 		b.WriteString("- Notes:\n")
@@ -1231,8 +1247,8 @@ func WriteVault(root string, ef entities.EntitiesFile, opts Options) error {
 			fmt.Fprintf(&b, "- Tags: %s\n", strings.Join(aTags, ", "))
 		}
 		if len(workflowTickets) > 0 {
-			fmt.Fprintf(&b, "- Analyst cases: %s\n", formatTicketRefsMarkdown(workflowTickets, opts.JiraBaseURL, "_None_"))
-			b.WriteString("- Workflow source: Jira analyst case\n")
+			fmt.Fprintf(&b, "- Analyst cases: %s\n", formatTicketRefsMarkdown(workflowTickets, opts, "_None_"))
+			fmt.Fprintf(&b, "- Workflow source: %s analyst case\n", tracker)
 		}
 		if aUpdated != "" {
 			fmt.Fprintf(&b, "- Updated: %s\n", aUpdated)
@@ -1245,7 +1261,7 @@ func WriteVault(root string, ef entities.EntitiesFile, opts Options) error {
 			b.WriteString("_Add `analyst.notes` in front matter for findings, evidence pointers, and next steps._\n\n")
 		}
 
-		b.WriteString("\n> **Workflow note:** use Jira for analyst workflow state. This page is the evidence view; keep `analyst.ticketRefs`, notes, and tags aligned with the linked analyst case. Pull-based workflow writeback is legacy-only.\n")
+		fmt.Fprintf(&b, "\n> **Workflow note:** use %s for analyst workflow state. This page is the evidence view; keep `analyst.ticketRefs`, notes, and tags aligned with the linked analyst case. Pull-based workflow writeback is legacy-only.\n", tracker)
 		// Governance prompts
 		b.WriteString("\n### Governance\n\n")
 		b.WriteString("- False positive reason: \n")
@@ -1351,22 +1367,22 @@ func WriteVault(root string, ef entities.EntitiesFile, opts Options) error {
 		b.WriteString("- [Executive Summary](EXECUTIVE-SUMMARY.md)\n")
 		b.WriteString("\n")
 
-		jiraIssueCounts := map[string]int{}
+		trackerIssueCounts := map[string]int{}
 		for _, is := range issueSummaries {
-			jiraIssueCounts[jiraWorkflowBucket(is.Tickets, opts.JiraStatusByKey)]++
+			trackerIssueCounts[workflowBucket(is.Tickets, opts.JiraStatusByKey, tracker)]++
 		}
-		jiraOccurrenceCounts := map[string]int{}
+		trackerOccurrenceCounts := map[string]int{}
 		for _, o := range ef.Occurrences {
-			jiraOccurrenceCounts[jiraWorkflowBucket(occurrenceTicketRefs(o, findByID), opts.JiraStatusByKey)]++
+			trackerOccurrenceCounts[workflowBucket(occurrenceTicketRefs(o, findByID), opts.JiraStatusByKey, tracker)]++
 		}
 
-		triageSection.WriteString("## Jira references\n\n")
-		triageSection.WriteString("Analyst workflow status comes from Jira. The KB lists linked analyst cases and keeps lifecycle status as a historical snapshot only.\n\n")
+		fmt.Fprintf(&triageSection, "## %s references\n\n", tracker)
+		fmt.Fprintf(&triageSection, "Analyst workflow status comes from %s. The KB lists linked analyst cases and keeps lifecycle status as a historical snapshot only.\n\n", tracker)
 		triageSection.WriteString("| Analyst cases | Issues | Occurrences |\n| --- | --- | --- |\n")
-		for _, bucket := range sortedWorkflowBuckets(jiraIssueCounts, jiraOccurrenceCounts) {
-			fmt.Fprintf(&triageSection, "| %s | %d | %d |\n", bucket, jiraIssueCounts[bucket], jiraOccurrenceCounts[bucket])
+		for _, bucket := range sortedWorkflowBuckets(trackerIssueCounts, trackerOccurrenceCounts) {
+			fmt.Fprintf(&triageSection, "| %s | %d | %d |\n", escapeTable(bucket), trackerIssueCounts[bucket], trackerOccurrenceCounts[bucket])
 		}
-		triageSection.WriteString("\n_No Jira case_ means no linked analyst case was present in `analyst.ticketRefs`. Low and informational findings need the `case-ticket` tag when they should open a Jira case.\n")
+		fmt.Fprintf(&triageSection, "\n_%s_ means no linked analyst case was present in `analyst.ticketRefs`. Low and informational findings need the `case-ticket` tag when they should open a %s case.\n", noCase, tracker)
 		triageSection.WriteString("\n")
 		b.WriteString(triageSection.String())
 
@@ -1402,7 +1418,7 @@ func WriteVault(root string, ef entities.EntitiesFile, opts Options) error {
 					rule = "Rule"
 				}
 				endpoint := fmt.Sprintf("%s %s", strings.TrimSpace(is.Method), neuterURL(is.URL))
-				fmt.Fprintf(&b, "- [%s](%s) - %s | %s | Cases: %s\n", is.Alias, is.Link, titleASCII(is.Severity), endpoint, formatTicketRefsMarkdown(is.Tickets, opts.JiraBaseURL, "No Jira case"))
+				fmt.Fprintf(&b, "- [%s](%s) - %s | %s | Cases: %s\n", is.Alias, is.Link, titleASCII(is.Severity), endpoint, formatTicketRefsMarkdown(is.Tickets, opts, noCase))
 				fmt.Fprintf(&b, "  Rule: %s\n", rule)
 			}
 			b.WriteString("\n")
@@ -1433,10 +1449,10 @@ func WriteVault(root string, ef entities.EntitiesFile, opts Options) error {
 				rule := fallbackString(is.RuleTitle, "Rule")
 				fmt.Fprintf(&b, "| %s | [%s](%s) | %s %s | %s | %d | %s |\n",
 					titleASCII(is.Severity), is.Alias, is.Link,
-					strings.TrimSpace(is.Method), strings.TrimSpace(is.URL),
-					formatTicketRefsMarkdown(is.Tickets, opts.JiraBaseURL, "No Jira case"),
+					strings.TrimSpace(is.Method), escapeTable(is.URL),
+					formatTicketRefsMarkdown(is.Tickets, opts, noCase),
 					is.Occurrences,
-					rule,
+					escapeTable(rule),
 				)
 			}
 			b.WriteString("\n")
@@ -1507,13 +1523,13 @@ func WriteVault(root string, ef entities.EntitiesFile, opts Options) error {
 				if is, ok := issueByID[o.FindingID]; ok {
 					issueLabel = fallbackString(is.Alias, issueLabel)
 				}
-				analystCases := formatTicketRefsMarkdown(occurrenceTicketRefs(o, findByID), opts.JiraBaseURL, "No Jira case")
+				analystCases := formatTicketRefsMarkdown(occurrenceTicketRefs(o, findByID), opts, noCase)
 				fmt.Fprintf(&b, "| [%s](%s) | %s %s | %s | %s | %s | [%s](%s) |\n",
 					alias,
 					filepath.ToSlash(filepath.Join("occurrences", o.OccurrenceID+".md")),
 					strings.TrimSpace(o.Method),
-					strings.TrimSpace(o.URL),
-					param,
+					escapeTable(o.URL),
+					escapeTable(param),
 					titleASCII(sevTxt),
 					analystCases,
 					issueLabel,
@@ -1545,7 +1561,7 @@ func WriteVault(root string, ef entities.EntitiesFile, opts Options) error {
 					break
 				}
 				fmt.Fprintf(&b, "| [%s (Plugin %s)](%s) | %d | %d | %d | %d | %d |\n",
-					ds.Title, ds.Plugin, ds.Link,
+					escapeTable(ds.Title), ds.Plugin, ds.Link,
 					ds.Severity["high"], ds.Severity["medium"], ds.Severity["low"], ds.Severity["info"],
 					ds.Total,
 				)
@@ -1556,7 +1572,7 @@ func WriteVault(root string, ef entities.EntitiesFile, opts Options) error {
 		// Domain table (this run)
 		if len(domainTotals) > 0 {
 			domainSection.WriteString("## By domain\n\n")
-			domainSection.WriteString("Workflow status comes from Jira. This page groups exposure by domain and severity only.\n\n")
+			fmt.Fprintf(&domainSection, "Workflow status comes from %s. This page groups exposure by domain and severity only.\n\n", tracker)
 			domainSection.WriteString("| Domain | Occurrences | High | Medium | Low | Info |\n| --- | --- | --- | --- | --- | --- |\n")
 			var doms []string
 			for d := range domainTotals {
@@ -1566,7 +1582,7 @@ func WriteVault(root string, ef entities.EntitiesFile, opts Options) error {
 			for _, d := range doms {
 				ss := domainSeverityCounts[d]
 				fmt.Fprintf(&domainSection, "| %s | %d | %d | %d | %d | %d |\n",
-					d, domainTotals[d],
+					escapeTable(d), domainTotals[d],
 					ss["high"], ss["medium"], ss["low"], ss["info"],
 				)
 			}
@@ -1645,7 +1661,7 @@ func WriteVault(root string, ef entities.EntitiesFile, opts Options) error {
 							dateRange = st.minDate + " \u2192 " + st.maxDate
 						}
 						fmt.Fprintf(&domainSection, "| %s | %d | %d | %d | %d | %d | %s |\n",
-							sn, st.count, st.high, st.med, st.low, st.info, dateRange,
+							escapeTable(sn), st.count, st.high, st.med, st.low, st.info, dateRange,
 						)
 					}
 					domainSection.WriteString("\n")
@@ -1665,7 +1681,7 @@ func WriteVault(root string, ef entities.EntitiesFile, opts Options) error {
 			}
 			sort.Strings(scans)
 			for _, s := range scans {
-				fmt.Fprintf(&b, "| %s | %d |\n", s, histScanTotals[s])
+				fmt.Fprintf(&b, "| %s | %d |\n", escapeTable(s), histScanTotals[s])
 			}
 			b.WriteString("\n")
 		}
@@ -1716,7 +1732,7 @@ func WriteVault(root string, ef entities.EntitiesFile, opts Options) error {
 			if len(openFindings) > 0 {
 				var qb strings.Builder
 				qb.WriteString("## Priority evidence queue\n\n")
-				qb.WriteString("_Severity-sorted KB evidence. Jira remains the source of truth for open/done workflow state._\n\n")
+				fmt.Fprintf(&qb, "_Severity-sorted KB evidence. %s remains the source of truth for open/done workflow state._\n\n", tracker)
 				sevBands := []struct {
 					Label string
 					Key   string
@@ -1845,8 +1861,11 @@ func WriteVault(root string, ef entities.EntitiesFile, opts Options) error {
 					if len(is.Tickets) > 0 {
 						tickets = strings.Join(is.Tickets, ", ")
 					}
-					fmt.Fprintf(&tc, "| [[%s|%s]] | %s | %s | %s | %s | %s | %s |\n",
-						is.Link, fallbackString(is.Alias, is.PluginID), ruleTitle, endpoint, scans, tuneTag, owner, tickets)
+					// Standard md link, not a wikilink: the "|" inside [[link|alias]]
+					// splits the table cell in any CommonMark renderer (Forgejo wiki,
+					// GitHub) and needs escaping even in Obsidian.
+					fmt.Fprintf(&tc, "| [%s](%s) | %s | %s | %s | %s | %s | %s |\n",
+						fallbackString(is.Alias, is.PluginID), is.Link, escapeTable(ruleTitle), escapeTable(endpoint), scans, tuneTag, escapeTable(owner), escapeTable(tickets))
 				}
 				tc.WriteString("\nWorkflow: investigate the rule (threshold, strength, or scope), open a detection-tuning task in your normal queue, and clear the `tune-scan` tag once the scanner config is updated.\n")
 			}
@@ -1877,7 +1896,7 @@ func WriteVault(root string, ef entities.EntitiesFile, opts Options) error {
 					continue
 				}
 				sevTxt, _ := deriveSeverity(o.Risk, o.RiskCode)
-				analystCases := formatTicketRefsMarkdown(occurrenceTicketRefs(o, findByID), opts.JiraBaseURL, "No Jira case")
+				analystCases := formatTicketRefsMarkdown(occurrenceTicketRefs(o, findByID), opts, noCase)
 				issueLink := filepath.ToSlash(filepath.Join("findings", o.FindingID+".md"))
 				issueLabel := strings.TrimSpace(o.FindingID)
 				if is, ok := issueByID[o.FindingID]; ok {
@@ -1886,7 +1905,7 @@ func WriteVault(root string, ef entities.EntitiesFile, opts Options) error {
 				fmt.Fprintf(&spot, "| [%s](%s) | %s %s | %s | %s | [%s](%s) |\n",
 					occAliasUltraCompact(o, ""),
 					filepath.ToSlash(filepath.Join("occurrences", o.OccurrenceID+".md")),
-					strings.TrimSpace(o.Method), strings.TrimSpace(o.URL),
+					strings.TrimSpace(o.Method), escapeTable(o.URL),
 					titleASCII(sevTxt),
 					analystCases,
 					issueLabel, issueLink)
@@ -1900,7 +1919,7 @@ func WriteVault(root string, ef entities.EntitiesFile, opts Options) error {
 	if err := writeLegend(root); err != nil {
 		return err
 	}
-	if err := writeTriageGuide(root); err != nil {
+	if err := writeTriageGuide(root, opts); err != nil {
 		return err
 	}
 	if err := writeByScan(root, ef, opts); err != nil {
@@ -2120,6 +2139,14 @@ func findAliasUltraCompact(f entities.Finding, ruleName string) string {
 		return acro + "-" + code
 	}
 	return acro + " " + base + "-" + code
+}
+
+// linkAliasSafe makes a string safe to use as link display text (wikilink
+// alias or markdown link text): square brackets nest/terminate link syntax in
+// both Obsidian and CommonMark, so they are swapped for parentheses.
+func linkAliasSafe(s string) string {
+	s = strings.ReplaceAll(s, "[", "(")
+	return strings.ReplaceAll(s, "]", ")")
 }
 
 func occAliasUltraCompact(o entities.Occurrence, ruleName string) string {
@@ -2998,19 +3025,28 @@ func formatListOrPlaceholder(items []string, placeholder string) string {
 	return strings.Join(items, ", ")
 }
 
-func formatTicketRefsMarkdown(refs []string, jiraBaseURL, placeholder string) string {
+// trackerName returns the display name of the external issue tracker for
+// generated prose, defaulting to Jira for backward compatibility.
+func (o Options) trackerName() string {
+	if t := strings.TrimSpace(o.Tracker); t != "" {
+		return t
+	}
+	return "Jira"
+}
+
+func formatTicketRefsMarkdown(refs []string, opts Options, placeholder string) string {
 	items := trimStrings(refs)
 	if len(items) == 0 {
 		return placeholder
 	}
 	formatted := make([]string, 0, len(items))
 	for _, ref := range items {
-		formatted = append(formatted, formatTicketRefMarkdown(ref, jiraBaseURL))
+		formatted = append(formatted, formatTicketRefMarkdown(ref, opts))
 	}
 	return strings.Join(formatted, ", ")
 }
 
-func formatTicketRefMarkdown(ref, jiraBaseURL string) string {
+func formatTicketRefMarkdown(ref string, opts Options) string {
 	ref = strings.TrimSpace(ref)
 	if ref == "" {
 		return ""
@@ -3018,8 +3054,13 @@ func formatTicketRefMarkdown(ref, jiraBaseURL string) string {
 	if isHTTPURL(ref) {
 		return fmt.Sprintf("[%s](%s)", ref, ref)
 	}
-	if isJiraIssueKey(ref) && strings.TrimSpace(jiraBaseURL) != "" {
-		base := strings.TrimRight(strings.TrimSpace(jiraBaseURL), "/")
+	if opts.TicketURLFn != nil {
+		if u := strings.TrimSpace(opts.TicketURLFn(ref)); u != "" {
+			return fmt.Sprintf("[%s](%s)", ref, u)
+		}
+	}
+	if isJiraIssueKey(ref) && strings.TrimSpace(opts.JiraBaseURL) != "" {
+		base := strings.TrimRight(strings.TrimSpace(opts.JiraBaseURL), "/")
 		return fmt.Sprintf("[%s](%s/browse/%s)", ref, base, ref)
 	}
 	return ref
@@ -3045,10 +3086,10 @@ func primaryJiraStatus(refs []string, statusByKey map[string]string) string {
 	return ""
 }
 
-func jiraWorkflowBucket(refs []string, statusByKey map[string]string) string {
+func workflowBucket(refs []string, statusByKey map[string]string, tracker string) string {
 	cleanRefs := trimStrings(refs)
 	if len(cleanRefs) == 0 {
-		return "No Jira case"
+		return "No " + tracker + " case"
 	}
 	var labels []string
 	for _, ref := range cleanRefs {
@@ -3062,7 +3103,7 @@ func jiraWorkflowBucket(refs []string, statusByKey map[string]string) string {
 		}
 	}
 	if len(labels) == 0 {
-		return "Linked Jira case"
+		return "Linked " + tracker + " case"
 	}
 	return strings.Join(labels, ", ")
 }
@@ -3128,10 +3169,13 @@ func sortedWorkflowBuckets(countMaps ...map[string]int) []string {
 }
 
 func workflowBucketRank(bucket string) int {
-	switch strings.ToLower(strings.TrimSpace(bucket)) {
-	case "jira status unavailable":
+	// Tracker-agnostic: "No <tracker> case" sorts last, "<tracker> status
+	// unavailable" second-to-last, real case buckets first.
+	b := strings.ToLower(strings.TrimSpace(bucket))
+	switch {
+	case strings.HasSuffix(b, "status unavailable"):
 		return 90
-	case "no jira case":
+	case strings.HasPrefix(b, "no ") && strings.HasSuffix(b, " case"):
 		return 100
 	default:
 		return 10

--- a/zap-kb/internal/output/obsidian/obsidian_test.go
+++ b/zap-kb/internal/output/obsidian/obsidian_test.go
@@ -1369,6 +1369,10 @@ func TestWriteVault_ForgejoTrackerLinkifiesRepoRefs(t *testing.T) {
 	if !strings.Contains(body, "- Workflow source: Forgejo analyst case") {
 		t.Errorf("finding workflow prose should name Forgejo:\n%s", body)
 	}
+	// The KB-finding noun is renamed to avoid colliding with Forgejo's Issues tab.
+	if !strings.Contains(body, "# Finding find-fj") || strings.Contains(body, "# Issue find-fj") {
+		t.Errorf("finding page H1 should read 'Finding', not 'Issue':\n%s", body)
+	}
 
 	idxData, err := os.ReadFile(filepath.Join(root, "INDEX.md"))
 	if err != nil {
@@ -1380,6 +1384,21 @@ func TestWriteVault_ForgejoTrackerLinkifiesRepoRefs(t *testing.T) {
 	}
 	if strings.Contains(idx, "Jira") {
 		t.Errorf("INDEX must not mention Jira when the tracker is Forgejo:\n%s", idx)
+	}
+	if !strings.Contains(idx, "## Findings") || strings.Contains(idx, "## Issues") {
+		t.Errorf("INDEX section should be 'Findings', not 'Issues':\n%s", idx)
+	}
+	if !strings.Contains(idx, "[Findings](issues.md)") {
+		t.Errorf("INDEX quick-nav should link 'Findings':\n%s", idx)
+	}
+
+	// The findings section page must exist and be titled "Findings".
+	secData, err := os.ReadFile(filepath.Join(root, "issues.md"))
+	if err != nil {
+		t.Fatalf("ReadFile issues.md: %v", err)
+	}
+	if !strings.HasPrefix(string(secData), "# Findings") {
+		t.Errorf("section page should be titled Findings:\n%s", string(secData)[:40])
 	}
 }
 

--- a/zap-kb/internal/output/obsidian/obsidian_test.go
+++ b/zap-kb/internal/output/obsidian/obsidian_test.go
@@ -1274,6 +1274,115 @@ func TestWriteVault_FindingWorkflowUsesFindingAnalystData(t *testing.T) {
 	}
 }
 
+// The finding page's occurrence rollup must keep its wikilink intact when the
+// occurrence has a param: square brackets in the alias ("[q]") terminate the
+// wikilink early and break the rendered link.
+func TestWriteVault_OccurrenceCaptionWithParamStaysLinkable(t *testing.T) {
+	root := t.TempDir()
+	def := entities.Definition{DefinitionID: "def-sqli", PluginID: "40018", Alert: "SQL Injection"}
+	finding := entities.Finding{
+		FindingID:    "find-sqli",
+		DefinitionID: def.DefinitionID,
+		PluginID:     def.PluginID,
+		URL:          "https://example.com/rest/products/search?q=x",
+		Method:       "GET",
+		Risk:         "High",
+	}
+	occ := entities.Occurrence{
+		OccurrenceID: "occ-sqli",
+		FindingID:    finding.FindingID,
+		DefinitionID: def.DefinitionID,
+		URL:          finding.URL,
+		Method:       "GET",
+		Param:        "q",
+		Risk:         "High",
+	}
+	if err := WriteVault(root, entities.EntitiesFile{
+		SchemaVersion: "1",
+		Definitions:   []entities.Definition{def},
+		Findings:      []entities.Finding{finding},
+		Occurrences:   []entities.Occurrence{occ},
+	}, Options{}); err != nil {
+		t.Fatalf("WriteVault: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(root, "findings", "find-sqli.md"))
+	if err != nil {
+		t.Fatalf("ReadFile finding page: %v", err)
+	}
+	body := string(data)
+	if !strings.Contains(body, "[[occurrences/occ-sqli.md|GET /rest/products/search (q)]]") {
+		t.Errorf("occurrence rollup wikilink malformed or missing:\n%s", body)
+	}
+	if strings.Contains(body, "(q)]]]") || strings.Contains(body, "[q]]]") {
+		t.Errorf("alias still carries link-breaking brackets:\n%s", body)
+	}
+}
+
+// With Tracker "Forgejo" and a TicketURLFn, generated prose names Forgejo and
+// repo issue refs ("owner/repo#N") become live links instead of dead text.
+func TestWriteVault_ForgejoTrackerLinkifiesRepoRefs(t *testing.T) {
+	root := t.TempDir()
+	def := entities.Definition{DefinitionID: "def-fj", PluginID: "10038", Alert: "CSP Header Not Set"}
+	finding := entities.Finding{
+		FindingID:    "find-fj",
+		DefinitionID: def.DefinitionID,
+		PluginID:     def.PluginID,
+		URL:          "https://example.com/api/login",
+		Method:       "GET",
+		Risk:         "Medium",
+		Analyst:      &entities.Analyst{TicketRefs: []string{"acme/kb#7"}},
+	}
+	occ := entities.Occurrence{
+		OccurrenceID: "occ-fj",
+		FindingID:    finding.FindingID,
+		DefinitionID: def.DefinitionID,
+		URL:          finding.URL,
+		Method:       finding.Method,
+		Risk:         "Medium",
+	}
+	opts := Options{
+		Tracker: "Forgejo",
+		TicketURLFn: func(ref string) string {
+			if ref == "acme/kb#7" {
+				return "https://forge.example/acme/kb/issues/7"
+			}
+			return ""
+		},
+	}
+	if err := WriteVault(root, entities.EntitiesFile{
+		SchemaVersion: "1",
+		Definitions:   []entities.Definition{def},
+		Findings:      []entities.Finding{finding},
+		Occurrences:   []entities.Occurrence{occ},
+	}, opts); err != nil {
+		t.Fatalf("WriteVault: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(root, "findings", "find-fj.md"))
+	if err != nil {
+		t.Fatalf("ReadFile finding page: %v", err)
+	}
+	body := string(data)
+	if !strings.Contains(body, "[acme/kb#7](https://forge.example/acme/kb/issues/7)") {
+		t.Errorf("Forgejo issue ref not linkified:\n%s", body)
+	}
+	if !strings.Contains(body, "- Workflow source: Forgejo analyst case") {
+		t.Errorf("finding workflow prose should name Forgejo:\n%s", body)
+	}
+
+	idxData, err := os.ReadFile(filepath.Join(root, "INDEX.md"))
+	if err != nil {
+		t.Fatalf("ReadFile INDEX.md: %v", err)
+	}
+	idx := string(idxData)
+	if !strings.Contains(idx, "## Forgejo references") {
+		t.Errorf("INDEX should carry the Forgejo references section:\n%s", idx)
+	}
+	if strings.Contains(idx, "Jira") {
+		t.Errorf("INDEX must not mention Jira when the tracker is Forgejo:\n%s", idx)
+	}
+}
+
 func TestWriteVault_OccurrenceTrafficRendersHTTPBlocks(t *testing.T) {
 	root := t.TempDir()
 	def := entities.Definition{DefinitionID: "def-traffic", PluginID: "10001", Alert: "Traffic Alert"}
@@ -1472,7 +1581,7 @@ func TestWriteVault_ByDomainOmitsLocalStatusBuckets(t *testing.T) {
 
 func TestWriteTriageGuideUsesJiraAsWorkflowSource(t *testing.T) {
 	root := t.TempDir()
-	if err := writeTriageGuide(root); err != nil {
+	if err := writeTriageGuide(root, Options{}); err != nil {
 		t.Fatalf("writeTriageGuide: %v", err)
 	}
 	data, err := os.ReadFile(filepath.Join(root, "TRIAGE-GUIDE.md"))
@@ -1485,6 +1594,26 @@ func TestWriteTriageGuideUsesJiraAsWorkflowSource(t *testing.T) {
 	}
 	if strings.Contains(guide, "| open | New, not yet reviewed |") || strings.Contains(guide, "Status values") {
 		t.Fatalf("triage guide should not document generated KB status as the workflow:\n%s", guide)
+	}
+}
+
+// With a non-Jira tracker configured the guide must not mention Jira or
+// Confluence at all — the prose follows the configured tracker/surface.
+func TestWriteTriageGuideTrackerAgnostic(t *testing.T) {
+	root := t.TempDir()
+	if err := writeTriageGuide(root, Options{Tracker: "Forgejo"}); err != nil {
+		t.Fatalf("writeTriageGuide: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(root, "TRIAGE-GUIDE.md"))
+	if err != nil {
+		t.Fatalf("ReadFile TRIAGE-GUIDE.md: %v", err)
+	}
+	guide := string(data)
+	if !strings.Contains(guide, "Forgejo is the source of truth") {
+		t.Fatalf("triage guide should direct analysts to Forgejo:\n%s", guide)
+	}
+	if strings.Contains(guide, "Jira") || strings.Contains(guide, "Confluence") {
+		t.Fatalf("Forgejo triage guide must not reference the Atlassian stack:\n%s", guide)
 	}
 }
 


### PR DESCRIPTION
## Summary

Completes the Forgejo sink follow-up work that landed after PR #93:

- repairs and stabilizes Forgejo wiki links
- makes generated vault wording tracker-neutral while preserving Jira behavior
- adds wiki-only publishing and first-publish issue cross-links
- documents the Forgejo label-state workflow convention
- adds stronger credential and PII redaction for shared Forgejo output

## Impact

The Forgejo sink now supports issue+wiki and wiki-only deployments, publishes correct cross-links on the first run, avoids duplicate or broken wiki navigation, and redacts common secret/PII patterns by default.

## Validation

- `go build ./...`
- `go test -timeout 150s ./...`
- `go vet ./...`
- live publish against Forgejo 9.0.3: 8 issues and 57 wiki pages, zero errors
- idempotency rerun: 0 issues created, 8 skipped; 0 wiki pages changed, 57 skipped