### PR TITLE
feat(deploy): standalone sink-agnostic zap-kb container image + portable Job

### DIFF
--- a/zap-kb/deploy/Dockerfile
+++ b/zap-kb/deploy/Dockerfile
@@ -1,0 +1,43 @@
+# syntax=docker/dockerfile:1
+#
+# Standalone, sink-agnostic zap-kb image.
+#
+# Unlike ../Dockerfile (a fat OWASP ZAP runtime) and ../../deploy/k8s/Dockerfile
+# (the Forgejo-coupled publisher), this image is JUST the zap-kb CLI on a minimal
+# base. It carries no scanner and no sink wiring — every behaviour is chosen at
+# run time via args/env, so the same image normalizes, enriches, dumps, or
+# publishes to any sink (Forgejo, Jira, Confluence, JSON).
+#
+# Build context is the module dir (zap-kb/):
+#   docker build -f deploy/Dockerfile -t zap-kb:standalone .
+ARG GO_VERSION=1.24
+
+FROM golang:${GO_VERSION}-alpine AS build
+WORKDIR /src
+# Warm the module cache before copying sources.
+COPY go.mod go.sum ./
+RUN go mod download
+COPY cmd ./cmd
+COPY internal ./internal
+# Fully static (CGO off) so the binary runs on any minimal base.
+RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/zap-kb ./cmd/zap-kb
+
+FROM alpine:3.20
+LABEL org.opencontainers.image.title="zap-kb"
+LABEL org.opencontainers.image.description="DevSecOps KB normalizer/publisher CLI — sink-agnostic, standalone"
+LABEL org.opencontainers.image.source="https://github.com/Warlockobama/DevSecOpsKB"
+
+# ca-certificates: outbound HTTPS to trackers (Jira/Confluence/Forgejo).
+# tzdata: stable RFC3339 timestamps. A non-root user owns the /work dir so the
+# CLI can write outputs there both under `docker run` and in a pod.
+RUN apk add --no-cache ca-certificates tzdata \
+ && adduser -D -H -u 65532 kb \
+ && mkdir -p /work && chown kb:kb /work
+
+COPY --from=build /out/zap-kb /usr/local/bin/zap-kb
+
+USER 65532:65532
+WORKDIR /work
+ENTRYPOINT ["zap-kb"]
+# Default to the offline help/self-test; real runs override args.
+CMD ["-h"]

--- a/zap-kb/deploy/README.md
+++ b/zap-kb/deploy/README.md
@@ -1,0 +1,80 @@
+# Standalone `zap-kb` container
+
+A minimal, **sink-agnostic** image of the `zap-kb` CLI plus a portable Job
+manifest you can drop into any Kubernetes cluster. Nothing here is tied to the
+Forgejo stack in [`../../deploy/k8s`](../../deploy/k8s) — every behaviour is
+chosen at run time via args/env, so the same image normalizes, enriches, dumps,
+or publishes to any sink (Forgejo, Jira, Confluence, JSON).
+
+| File | Purpose |
+|------|---------|
+| [`Dockerfile`](Dockerfile) | Minimal image: just the `zap-kb` binary on Alpine, non-root, no scanner |
+| [`zap-kb-job.yaml`](zap-kb-job.yaml) | Self-contained ConfigMap + Secret + Job; offline self-test by default |
+
+## How it differs from the other images
+
+| Image | Base | Contains | Use |
+|-------|------|----------|-----|
+| `../Dockerfile` | OWASP ZAP | ZAP + `zap-kb` + scan scripts | scan **and** publish in one fat image |
+| `../../deploy/k8s/Dockerfile` | Alpine | `zap-kb` | the Forgejo-coupled publisher CronJob |
+| **`deploy/Dockerfile`** (this) | Alpine | `zap-kb` only | **portable**, sink chosen per-run |
+
+## Build
+
+From the module dir (`zap-kb/`):
+
+```bash
+docker build -f deploy/Dockerfile -t zap-kb:standalone .
+```
+
+Smoke-test it locally (offline, non-root, writes to `/work`):
+
+```bash
+docker run --rm zap-kb:standalone -h
+docker run --rm -v "$PWD/out:/work" zap-kb:standalone \
+  -init -format entities -plugins 10038,10020,10016 -out /work/entities.json
+```
+
+## Run in a pod
+
+1. **Get the image to the cluster.** Either push to a registry and edit the
+   `image:` in `zap-kb-job.yaml`, or load the local image:
+
+   ```bash
+   # kind:
+   kind load docker-image zap-kb:standalone
+   # docker-desktop's built-in k8s already sees local images (imagePullPolicy: IfNotPresent)
+   ```
+
+2. **Apply the Job.** The default args run an offline self-test — no external
+   service needed:
+
+   ```bash
+   kubectl apply -f deploy/zap-kb-job.yaml
+   kubectl wait --for=condition=complete job/zap-kb --timeout=120s
+   kubectl logs job/zap-kb
+   ```
+
+   You should see `Init summary: defs total=… ` and the Job complete. That
+   proves the image runs `zap-kb` in a pod.
+
+3. **Do real work.** Edit the container `args` in `zap-kb-job.yaml` (a commented
+   Forgejo publish block is included), fill the ConfigMap/Secret, and re-apply.
+   For a real publish the pod needs an `entities.json` to read — mount a PVC at
+   `/work` shared with whatever produced it (a scanner pod, or
+   `kubectl cp`-ed in), instead of the `emptyDir`.
+
+### Ad-hoc one-off (no manifest)
+
+```bash
+kubectl run zap-kb --rm -it --restart=Never --image=zap-kb:standalone -- \
+  -init -format entities -plugins 10038 -out /work/entities.json
+```
+
+## Security posture
+
+The manifest runs the container hardened: non-root (uid 65532),
+`readOnlyRootFilesystem`, all capabilities dropped, `RuntimeDefault` seccomp.
+Writes are confined to the mounted `/work` (outputs) and `/tmp` (a redacted
+vault is staged here during `-forgejo-wiki` publish). Published content is
+redacted by default; see the main docs for `-forgejo-redact`.

--- a/zap-kb/deploy/zap-kb-job.yaml
+++ b/zap-kb/deploy/zap-kb-job.yaml
@@ -1,0 +1,118 @@
+# Standalone, sink-agnostic zap-kb run as a Kubernetes Job.
+#
+# Drop into ANY cluster — it is not tied to the Forgejo stack in
+# ../../deploy/k8s. `kubectl apply -f zap-kb-job.yaml` runs an OFFLINE self-test
+# by default (the `-init` args below need no external service): it builds a
+# normalized entities.json into an emptyDir, proving the image runs in a pod.
+#
+# To do real work, edit the container `args` (and the ConfigMap/Secret) to point
+# at your sink — a commented Forgejo publish block is included as a template.
+#
+# Image: build & load/push first (see deploy/README.md):
+#   docker build -f deploy/Dockerfile -t zap-kb:standalone .
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: zap-kb-config
+  labels:
+    app.kubernetes.io/name: zap-kb
+data:
+  # Generic, non-secret knobs referenced from the Job args via $(VAR).
+  # Unused by the default offline run; fill in for your sink.
+  FORMAT: "entities"
+  MIN_RISK: "medium"
+  # --- Forgejo example -------------------------------------------------
+  # FORGEJO_URL: "http://forgejo.devsecops-kb.svc.cluster.local:3000"
+  # FORGEJO_OWNER: "devsecops"
+  # FORGEJO_REPO: "kb"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: zap-kb-secrets
+  labels:
+    app.kubernetes.io/name: zap-kb
+type: Opaque
+stringData:
+  # Replace with your tracker token(s). Unused by the default offline run.
+  # Leave as-is for the self-test; the env var is simply never read.
+  FORGEJO_TOKEN: "REPLACE_ME"
+  # JIRA_API_TOKEN: "REPLACE_ME"
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: zap-kb
+  labels:
+    app.kubernetes.io/name: zap-kb
+spec:
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 600 # auto-clean the finished Job after 10 min
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: zap-kb
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532 # make the mounted /work + /tmp writable to the non-root user
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: zap-kb
+          # Local tag: `docker build` it, then load into your cluster (kind:
+          # `kind load docker-image zap-kb:standalone`) or push to a registry and
+          # set the full ref here. IfNotPresent so a preloaded local image is used.
+          image: zap-kb:standalone
+          imagePullPolicy: IfNotPresent
+          envFrom:
+            - configMapRef:
+                name: zap-kb-config
+            - secretRef:
+                name: zap-kb-secrets
+          # DEFAULT: offline self-test — no external service required.
+          args:
+            - "-init"
+            - "-format=entities"
+            - "-plugins=10038,10020,10016"
+            - "-out=/work/entities.json"
+          # --- Publish to Forgejo (replace the args above) ---------------------
+          # args:
+          #   - "-entities-in=/work/entities.json"
+          #   - "-format=obsidian"
+          #   - "-obsidian-dir=/work/vault"
+          #   - "-forgejo-url=$(FORGEJO_URL)"
+          #   - "-forgejo-owner=$(FORGEJO_OWNER)"
+          #   - "-forgejo-repo=$(FORGEJO_REPO)"
+          #   - "-forgejo-min-risk=$(MIN_RISK)"
+          #   - "-forgejo-issues"
+          #   - "-forgejo-wiki"
+          # FORGEJO_TOKEN is read from the Secret env automatically.
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true # writes go only to the mounted volumes below
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: work
+              mountPath: /work
+            - name: tmp
+              mountPath: /tmp # zap-kb stages a redacted vault here during wiki publish
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "64Mi"
+            limits:
+              cpu: "1"
+              memory: "512Mi"
+      volumes:
+        # Swap `work` for a PVC to share an entities.json with a scanner pod, or
+        # to persist the published vault across runs.
+        - name: work
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}

--- a/zap-kb/docs/container.md
+++ b/zap-kb/docs/container.md
@@ -1,5 +1,9 @@
 # Container Image
 
+> **Just need `zap-kb` in a pod?** For a minimal, sink-agnostic image (no ZAP)
+> plus a portable Kubernetes Job manifest, see [`../deploy/README.md`](../deploy/README.md).
+> This page covers the fuller ZAP-based runtime image below.
+
 `zap-kb/Dockerfile` builds a ZAP-based runtime image that includes:
 
 - OWASP ZAP from `ghcr.io/zaproxy/zaproxy:stable`.


### PR DESCRIPTION
Adds a minimal, sink-agnostic `zap-kb` container image plus a portable Kubernetes Job manifest, decoupled from the Forgejo-specific `deploy/k8s` stack.

- `zap-kb/deploy/Dockerfile` — static `zap-kb` binary on Alpine, non-root (uid 65532), ca-certs; ~32.5 MB, no scanner/sink baked in.
- `zap-kb/deploy/zap-kb-job.yaml` — self-contained ConfigMap + Secret + Job; offline `-init` self-test by default, Forgejo publish template included; hardened securityContext (non-root, read-only rootfs, all caps dropped, RuntimeDefault seccomp).
- `zap-kb/deploy/README.md` + cross-ref from `docs/container.md`.

Verified: builds clean, `docker run` writes a valid `entities.json`, and the Job runs to completion in-cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)