### PR TITLE
ci(deploy): publish zap-kb Atlassian image to GHCR

### DIFF
--- a/.github/workflows/zap-kb-image.yml
+++ b/.github/workflows/zap-kb-image.yml
@@ -1,0 +1,78 @@
+name: publish-zap-kb-image
+
+# Builds the ZAP -> Atlassian publisher image (zap-kb/deploy/Dockerfile) and
+# pushes it to GitHub Container Registry (ghcr.io/<owner>/zap-kb-atlassian).
+#
+# Triggers:
+#   - workflow_dispatch  : publish on demand (e.g. ghcr ":latest" off the default branch)
+#   - push tags v*       : publish a versioned image (1.2.3, 1.2, latest) alongside the binary release
+#   - pull_request        : build only (no push) to validate the Dockerfile
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+  pull_request:
+    paths:
+      - "zap-kb/deploy/Dockerfile"
+      - "zap-kb/go.mod"
+      - "zap-kb/go.sum"
+      - "zap-kb/cmd/**"
+      - "zap-kb/internal/**"
+      - ".github/workflows/zap-kb-image.yml"
+
+jobs:
+  image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Compute image name (ghcr requires lowercase)
+        run: echo "IMAGE=ghcr.io/${OWNER,,}/zap-kb-atlassian" >> "$GITHUB_ENV"
+        env:
+          OWNER: ${{ github.repository_owner }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Don't log in for PR builds (no push, and forks can't write packages).
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha,format=short
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: zap-kb
+          file: zap-kb/deploy/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            GO_VERSION=1.24
+          provenance: false

--- a/zap-kb/deploy/README.md
+++ b/zap-kb/deploy/README.md
@@ -39,6 +39,15 @@ docker tag zap-kb:atlassian ghcr.io/<org>/zap-kb-atlassian:1.0.0
 docker push ghcr.io/<org>/zap-kb-atlassian:1.0.0
 ```
 
+**CI:** [`.github/workflows/zap-kb-image.yml`](../../.github/workflows/zap-kb-image.yml)
+builds this image (multi-arch `linux/amd64,linux/arm64`) and pushes it to
+`ghcr.io/<owner>/zap-kb-atlassian` on a `v*` tag or manual *Run workflow*. Pull
+the published image with:
+
+```bash
+docker pull ghcr.io/warlockobama/zap-kb-atlassian:latest
+```
+
 ## Configuration (environment)
 
 Targets and credentials come from env (a ConfigMap + Secret); flags override env.


### PR DESCRIPTION
## What

Adds [`.github/workflows/zap-kb-image.yml`](.github/workflows/zap-kb-image.yml): builds the ZAP → Atlassian publisher image ([`zap-kb/deploy/Dockerfile`](zap-kb/deploy/Dockerfile)) and pushes it to **GitHub Container Registry** at `ghcr.io/warlockobama/zap-kb-atlassian`.

## Triggers

| Event | Behavior |
|-------|----------|
| `pull_request` (touching the image inputs) | **Build only** — validates the Dockerfile, no push |
| `push` tag `v*` | Build + push `1.2.3`, `1.2`, `latest` (multi-arch) |
| `workflow_dispatch` | Build + push on demand (`:latest` + short-sha off the default branch) |

- Multi-arch: `linux/amd64,linux/arm64` (QEMU + Buildx)
- Auth via the built-in `GITHUB_TOKEN` (`packages: write`); no extra secrets
- Tags via `docker/metadata-action`

## After merge — to publish

```bash
# versioned release (also cuts the Go binary release):
git tag v0.1.0 && git push origin v0.1.0
# …or Actions tab → publish-zap-kb-image → Run workflow  (pushes :latest)
```

Then: `docker pull ghcr.io/warlockobama/zap-kb-atlassian:latest`

> First publish creates the GHCR package as **private**; flip it to public (or grant pull access) in the package settings if external pulls are needed.

## Notes

- Docs: a CI pointer added to [`zap-kb/deploy/README.md`](zap-kb/deploy/README.md).
- This PR's own build runs in **build-only** mode (the workflow file isn't on `main` yet for tag/dispatch publishing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)